### PR TITLE
feat: add stationary phase cutting to API fitting pipeline

### DIFF
--- a/src/api/fitting.jl
+++ b/src/api/fitting.jl
@@ -108,6 +108,11 @@ function _fit_curve(
     # Legacy functions expect a 2×n matrix [times; values]
     data_mat = Matrix(transpose(hcat(times, curve)))
 
+    if opts.cut_stationary_phase
+        cutoff = _find_stationary_cutoff(data_mat, opts)
+        data_mat = data_mat[:, 1:cutoff]
+    end
+
     candidates = map(eachindex(spec.models)) do k
         model  = spec.models[k]
         p0     = _resolve_p0(spec.params[k], model, data_mat)

--- a/src/api/preprocessing.jl
+++ b/src/api/preprocessing.jl
@@ -146,8 +146,22 @@ function _apply_smoothing(
     end
 
     smoothing_str = _smoothing_symbol_to_string(opts.smooth_method)
-    smoothed = similar(curves)
-    for i in axes(curves, 1)
+    n_curves = size(curves, 1)
+
+    # Process first curve to determine output length (smoothing may shorten data)
+    curve_mat1 = Matrix(transpose(hcat(times, curves[1, :])))
+    result1 = smoothing_data(
+        curve_mat1;
+        method     = smoothing_str,
+        pt_avg     = opts.smooth_pt_avg,
+        thr_lowess = opts.lowess_frac,
+    )
+    n_out     = size(result1, 2)
+    new_times = Vector{Float64}(result1[1, :])
+    smoothed  = Matrix{Float64}(undef, n_curves, n_out)
+    smoothed[1, :] = result1[2, :]
+
+    for i in 2:n_curves
         curve_mat = Matrix(transpose(hcat(times, curves[i, :])))
         result = smoothing_data(
             curve_mat;
@@ -155,16 +169,17 @@ function _apply_smoothing(
             pt_avg     = opts.smooth_pt_avg,
             thr_lowess = opts.lowess_frac,
         )
-        # rolling_avg reduces length; pad with original tail if needed
-        n_out = size(result, 2)
-        if n_out == length(times)
+        ni = size(result, 2)
+        if ni == n_out
             smoothed[i, :] = result[2, :]
         else
-            smoothed[i, 1:n_out] = result[2, :]
-            smoothed[i, n_out+1:end] = curves[i, n_out+1:end]
+            # Unexpected length difference — fall back to first n_out values or padding
+            m = min(ni, n_out)
+            smoothed[i, 1:m]       = result[2, 1:m]
+            smoothed[i, m+1:n_out] .= result[2, end]
         end
     end
-    return smoothed, times
+    return smoothed, new_times
 end
 
 _smoothing_symbol_to_string(s::Symbol) = Dict(
@@ -332,6 +347,55 @@ function _apply_trend_labels(
         end
     end
     return new_labels
+end
+
+# ---------------------------------------------------------------------------
+# Stationary phase cutoff detection
+# ---------------------------------------------------------------------------
+
+"""
+    _find_stationary_cutoff(data_mat, opts) -> Int
+
+Given a `2×n` data matrix `[times; od_values]` and a `FitOptions`, return the
+column index at which the stationary phase begins. Returns `size(data_mat, 2)`
+(full length) when no stationary phase is detected.
+
+The algorithm:
+1. Restrict to time points where OD > `opts.stationary_thr_od`.
+2. Compute the specific growth rate (SGR) over the restricted data.
+3. Find the first window of `opts.stationary_win_size` consecutive points after
+   the SGR maximum where all SGR values are below
+   `maximum(SGR) × opts.stationary_percentile_thr`.
+4. Snap the cutoff forward to the OD peak within the next
+   `opts.stationary_win_size` time points (the OD may still rise after the SGR
+   threshold is crossed).
+"""
+function _find_stationary_cutoff(data_mat::Matrix{Float64}, opts::FitOptions)::Int
+    n = size(data_mat, 2)
+    index_od = findall(data_mat[2, :] .> opts.stationary_thr_od)
+    isempty(index_od) && return n
+
+    data_t = data_mat[:, index_od]
+    sgr = specific_gr_evaluation(data_t, opts.stationary_pt_smooth_derivative)
+    thr = maximum(sgr) * opts.stationary_percentile_thr
+    max_idx = argmax(sgr)
+    win = opts.stationary_win_size
+
+    # Guard: if fewer than win_size points exceed the threshold, the curve is
+    # flat / not growing — skip detection and use the full dataset (matches the
+    # behaviour of the legacy find_stationary_phase).
+    length(findall(sgr .> thr)) > win || return n
+
+    for i in max_idx:(length(sgr) - win)
+        if all(sgr[i:(i + win - 1)] .< thr)
+            base_idx   = i + index_od[1] - 1
+            search_end = min(base_idx + win, n)
+            peak_offset = argmax(data_mat[2, base_idx:search_end])
+            return base_idx + peak_offset - 1
+        end
+    end
+
+    return n
 end
 
 export preprocess

--- a/src/api/types.jl
+++ b/src/api/types.jl
@@ -97,6 +97,17 @@ Every field has a sensible default so users only override what they need.
 - `calibration_file::String = ""`: path to calibration CSV (required when `scattering_correction=true`).
 - `scattering_method::Symbol = :interpolation`: `:interpolation` or `:exp_fit`.
 
+# Stationary phase fields
+- `cut_stationary_phase::Bool = false`: truncate each curve at the onset of stationary
+  phase before fitting. Uses a specific-growth-rate threshold to locate the cutoff,
+  then snaps it to the OD peak within the next `stationary_win_size` time points.
+- `stationary_percentile_thr::Float64 = 0.05`: SGR drops below this fraction of its
+  maximum to trigger the cutoff.
+- `stationary_pt_smooth_derivative::Int = 10`: smoothing window for SGR evaluation.
+- `stationary_win_size::Int = 5`: look-ahead window for OD-peak snapping.
+- `stationary_thr_od::Float64 = 0.02`: minimum OD value; time points below this are
+  excluded before detecting stationary phase.
+
 # Clustering fields
 - `cluster::Bool = false`: cluster curves after preprocessing.
 - `n_clusters::Int = 3`: number of clusters (k for k-means).
@@ -132,6 +143,13 @@ Every field has a sensible default so users only override what they need.
     scattering_correction::Bool = false
     calibration_file::String    = ""
     scattering_method::Symbol   = :interpolation
+
+    # --- stationary phase detection ---
+    cut_stationary_phase::Bool             = false
+    stationary_percentile_thr::Float64     = 0.05
+    stationary_pt_smooth_derivative::Int   = 10
+    stationary_win_size::Int               = 5
+    stationary_thr_od::Float64             = 0.02
 
     # --- clustering ---
     cluster::Bool               = false


### PR DESCRIPTION
## Summary

- Adds `cut_stationary_phase` option to `FitOptions` that truncates each growth curve at the onset of stationary phase before fitting
- Detection uses a specific-growth-rate (SGR) threshold and snaps the cutoff to the local OD peak within a configurable look-ahead window
- Fixes smoothing to correctly handle variable-length output from `rolling_avg` by aligning all curves to the length of the first processed curve

## New `FitOptions` fields

| Field | Default | Description |
|---|---|---|
| `cut_stationary_phase` | `false` | Enable stationary phase truncation |
| `stationary_percentile_thr` | `0.05` | SGR fraction-of-max threshold |
| `stationary_pt_smooth_derivative` | `10` | Smoothing window for SGR evaluation |
| `stationary_win_size` | `5` | Look-ahead window for OD-peak snapping |
| `stationary_thr_od` | `0.02` | Minimum OD; points below excluded from detection |

## Test plan

- [ ] Fit a curve with `cut_stationary_phase=false` (default) — results unchanged
- [ ] Fit a curve with `cut_stationary_phase=true` — curve truncated at stationary onset before fitting
- [ ] Test with a flat/non-growing curve — detection gracefully skips and uses full data
- [ ] Verify smoothing produces consistent-length output across all wells