### PR TITLE
feat: exponential prototype cluster for shape-based classification

### DIFF
--- a/src/api/preprocessing.jl
+++ b/src/api/preprocessing.jl
@@ -286,11 +286,15 @@ prototypes, compute the mean of `data.curves[data.clusters .== k, :]` for each `
 `wcss` is the total SSE from the k-means step (0.0 when all curves were classified
 as constant).
 
-Three modes (evaluated in priority order):
+Modes (evaluated in priority order):
 1. `cluster_prescreen_constant=true`: quantile-ratio pre-screening identifies
    non-growing wells before k-means, which then runs on dynamic curves only.
 2. `cluster_trend_test=true`: OLS slope t-test post-hoc re-labels flat curves.
 3. Neither: plain k-means on all curves.
+
+When `cluster_exp_prototype=true`, an additional exponential shape cluster is
+added after k-means: each curve is tested against pre-built z-scored exponential
+prototypes and re-labelled if it is closer to them than to any k-means centroid.
 """
 function _cluster(
     curves::Matrix{Float64},
@@ -314,10 +318,23 @@ function _cluster(
         wcss   = result.totalcost
     end
 
+    if opts.cluster_exp_prototype
+        exp_label      = _exp_prototype_label(opts)
+        exp_protos     = _build_exp_prototypes(times)
+        centroids_norm = _compute_centroids(zscored_all, labels, opts.n_clusters)
+        labels         = _apply_exp_prototype_labels(zscored_all, labels, exp_protos,
+                                                     centroids_norm, exp_label)
+    end
+
     # Centroids in z-normalised space (shape prototypes, scale-independent).
     centroids = _compute_centroids(zscored_all, labels, opts.n_clusters)
     return labels, centroids, wcss
 end
+
+# The exponential prototype occupies label n_clusters-1 when constant
+# pre-screening is active (reserving n_clusters for constant), otherwise n_clusters.
+_exp_prototype_label(opts::FitOptions) =
+    opts.cluster_prescreen_constant ? opts.n_clusters - 1 : opts.n_clusters
 
 # ---------------------------------------------------------------------------
 # Constant pre-screening helpers
@@ -403,6 +420,65 @@ function _compute_centroids(
         centroids[k, :] = vec(mean(curves[idxs, :], dims=1))
     end
     return centroids
+end
+
+# ---------------------------------------------------------------------------
+# Exponential prototype helpers
+# ---------------------------------------------------------------------------
+
+"""
+    _build_exp_prototypes(times) -> Vector{Vector{Float64}}
+
+Build z-scored exponential shape prototypes using bases 2⁶..2¹⁶.
+Each prototype is `(b^τ - 1)/(b - 1)` evaluated at normalised time τ ∈ [0,1],
+then z-score normalised so distances are shape-only comparisons.
+"""
+function _build_exp_prototypes(times::Vector{Float64})::Vector{Vector{Float64}}
+    tmin, tmax = minimum(times), maximum(times)
+    dt = max(tmax - tmin, 1e-12)
+    tau = (times .- tmin) ./ dt
+
+    protos = Vector{Vector{Float64}}()
+    for exp_b in (2^6, 2^7, 2^8, 2^9, 2^10, 2^11, 2^12, 2^13, 2^14, 2^15, 2^16)
+        bf = Float64(exp_b)
+        y  = [(bf^t - 1.0) / (bf - 1.0) for t in tau]
+        push!(protos, _zscore_vec(y))
+    end
+    return protos
+end
+
+@inline function _zscore_vec(x::Vector{Float64})::Vector{Float64}
+    mu = mean(x); s = std(x; corrected=false)
+    s < 1e-12 ? zeros(length(x)) : (x .- mu) ./ s
+end
+
+"""
+    _apply_exp_prototype_labels(zscored, labels, exp_protos, centroids_norm, exp_label)
+
+For each curve, compare its squared distance to the nearest exponential prototype
+against the distance to the nearest k-means centroid. If the exponential is closer,
+reassign the curve to `exp_label`.
+"""
+function _apply_exp_prototype_labels(
+    zscored::Matrix{Float64},
+    labels::Vector{Int},
+    exp_protos::Vector{Vector{Float64}},
+    centroids_norm::Matrix{Float64},
+    exp_label::Int,
+)::Vector{Int}
+    new_labels = copy(labels)
+    for i in axes(zscored, 1)
+        xi = @view zscored[i, :]
+        # distance to nearest exponential prototype
+        d_exp = minimum(sum((xi .- p) .^ 2) for p in exp_protos)
+        # distance to assigned k-means centroid
+        lbl   = labels[i]
+        d_km  = sum((xi .- @view centroids_norm[lbl, :]) .^ 2)
+        if d_exp < d_km
+            new_labels[i] = exp_label
+        end
+    end
+    return new_labels
 end
 
 # Z-score each row (curve) over its time points; handle constant rows gracefully

--- a/src/api/types.jl
+++ b/src/api/types.jl
@@ -140,6 +140,13 @@ Every field has a sensible default so users only override what they need.
   tail in constant pre-screening.
 - `cluster_q_high::Float64 = 0.95`: upper quantile used to estimate the signal
   tail in constant pre-screening.
+- `cluster_exp_prototype::Bool = false`: add a dedicated "exponential" cluster
+  (label `n_clusters - 1` when used together with constant pre-screening, or
+  `n_clusters` when used alone). For each curve, the distance to the nearest
+  exponential shape prototype (z-scored, bases 2⁶..2¹⁶) is compared to the
+  distance to the nearest k-means centroid; the exponential label wins when
+  it is closer. Requires `n_clusters ≥ 3` when combined with constant pre-screening
+  (`n_clusters - 1` for exponential, `n_clusters` for constant), or ≥ 2 otherwise.
 
 After clustering, `processed.wcss` holds the within-cluster sum of squares. Run
 `preprocess` for `n_clusters = 2, 3, 4, ...` and plot `wcss` vs `n_clusters` to
@@ -191,6 +198,7 @@ find the elbow and choose the optimal number of clusters.
     cluster_tol_const::Float64       = 1.5
     cluster_q_low::Float64           = 0.05
     cluster_q_high::Float64          = 0.95
+    cluster_exp_prototype::Bool      = false
 
     # --- fitting ---
     loss::String                = "RE"

--- a/test/api/test_preprocessing.jl
+++ b/test/api/test_preprocessing.jl
@@ -38,6 +38,27 @@
         @test processed.wcss >= 0.0
     end
 
+    @testset "Exponential prototype cluster labels within 1..n_clusters" begin
+        opts = FitOptions(cluster=true, n_clusters=3,
+                          cluster_trend_test=false, cluster_exp_prototype=true)
+        processed = preprocess(data, opts)
+        @test all(1 .<= processed.clusters .<= 3)
+    end
+
+    @testset "Exponential prototype reassigns a clearly exponential curve" begin
+        # Build a plate where one curve is strongly exponential
+        t = data.times
+        exp_curve = 0.01 .* exp.(0.8 .* t)
+        mixed = vcat(data.curves, reshape(exp_curve, 1, :))
+        mixed_data = GrowthData(mixed, t, ["c$i" for i in 1:6])
+        opts = FitOptions(cluster=true, n_clusters=3,
+                          cluster_trend_test=false, cluster_exp_prototype=true)
+        processed = preprocess(mixed_data, opts)
+        exp_label = 3   # n_clusters when no constant pre-screening
+        # the exponential curve (last row) should be in the exp cluster
+        @test processed.clusters[end] == exp_label
+    end
+
     @testset "WCSS decreases as n_clusters increases" begin
         # More clusters → lower total SSE (elbow-plot property)
         wcss_vals = map(2:4) do k


### PR DESCRIPTION
Add cluster_exp_prototype::Bool to FitOptions. When true, after k-means each curve's distance to the nearest z-scored exponential shape prototype (bases 2^6..2^16) is compared to its distance to the assigned k-means centroid. The curve is re-labelled to the exponential cluster when the prototype wins.

The exponential label is n_clusters (plain k-means mode) or n_clusters-1 (constant pre-screening mode, where n_clusters is reserved for constant wells). Labels always remain within 1..n_clusters.