### PR TITLE
feat: replicate averaging in preprocessing pipeline

### DIFF
--- a/src/api/preprocessing.jl
+++ b/src/api/preprocessing.jl
@@ -44,6 +44,10 @@ processed = preprocess(raw_data, opts)
 function preprocess(data::GrowthData, opts::FitOptions)::GrowthData
     curves = data.curves   # n_curves × n_tp, never mutated in place
     times  = data.times
+    labels = data.labels
+
+    # Replicate averaging collapses curves with identical labels before any other step
+    curves, labels = _apply_replicate_averaging(curves, labels, opts)
 
     curves = _apply_scattering_correction(curves, times, opts)
 
@@ -56,7 +60,41 @@ function preprocess(data::GrowthData, opts::FitOptions)::GrowthData
     curves = _apply_negative_correction(curves, times, opts)
     curves, times = _apply_smoothing(curves, times, opts)   # Gaussian may change times
 
-    return GrowthData(curves, times, data.labels, clusters)
+    return GrowthData(curves, times, labels, clusters)
+end
+
+# ---------------------------------------------------------------------------
+# Step 0 — Replicate averaging
+# ---------------------------------------------------------------------------
+
+"""
+    _apply_replicate_averaging(curves, labels, opts) -> (Matrix{Float64}, Vector{String})
+
+When `opts.average_replicates=true`, average all curves that share the same label
+into a single row. Wells labelled `"b"` (blank) or `"X"` (discard) are excluded
+from averaging and dropped from the output — they are not biologically meaningful
+replicates. Returns the merged curves matrix and the deduplicated label vector.
+
+When `opts.average_replicates=false`, returns the inputs unchanged.
+"""
+function _apply_replicate_averaging(
+    curves::Matrix{Float64},
+    labels::Vector{String},
+    opts::FitOptions,
+)::Tuple{Matrix{Float64}, Vector{String}}
+    opts.average_replicates || return curves, labels
+
+    skip = ("b", "X")
+    unique_labels = unique(l for l in labels if l ∉ skip)
+    isempty(unique_labels) && return curves[Int[], :], String[]
+
+    n_tp  = size(curves, 2)
+    out   = Matrix{Float64}(undef, length(unique_labels), n_tp)
+    for (i, lbl) in enumerate(unique_labels)
+        idx = findall(==(lbl), labels)
+        out[i, :] = vec(mean(curves[idx, :], dims=1))
+    end
+    return out, unique_labels
 end
 
 # ---------------------------------------------------------------------------

--- a/src/api/types.jl
+++ b/src/api/types.jl
@@ -88,6 +88,10 @@ Every field has a sensible default so users only override what they need.
 - `gaussian_time_grid::Union{Nothing,Vector{Float64}} = nothing`: optional target
   time grid for Gaussian smoothing; when set, smoothed curves are evaluated at
   these times (interpolation). `nothing` keeps the original time grid.
+- `average_replicates::Bool = false`: before any other preprocessing step, average all
+  curves that share the same label into a single curve. Wells labelled `"b"` (blank) or
+  `"X"` (discard) are excluded and dropped from the output. Useful when the same
+  biological condition was measured in multiple wells.
 - `blank_subtraction::Bool = false`: subtract a blank value from all curves.
 - `blank_value::Float64 = 0.0`: constant blank to subtract when `blank_subtraction=true`.
 - `correct_negatives::Bool = false`: handle negative values after blank subtraction.
@@ -135,6 +139,7 @@ Every field has a sensible default so users only override what they need.
     lowess_frac::Float64        = 0.05
     gaussian_h_mult::Float64    = 2.0
     gaussian_time_grid::Union{Nothing, Vector{Float64}} = nothing
+    average_replicates::Bool    = false
     blank_subtraction::Bool     = false
     blank_value::Float64        = 0.0
     correct_negatives::Bool     = false

--- a/test/api/test_preprocessing.jl
+++ b/test/api/test_preprocessing.jl
@@ -18,6 +18,40 @@
         @test processed.curves ≈ data.curves .- 0.05
     end
 
+    @testset "Replicate averaging collapses duplicate labels" begin
+        # 4 curves: A appears twice, B appears twice
+        rep_curves = vcat(curves[1:2, :], curves[3:4, :])
+        rep_labels = ["A", "A", "B", "B"]
+        rep_data   = GrowthData(rep_curves, times, rep_labels)
+
+        opts = FitOptions(average_replicates=true)
+        processed = preprocess(rep_data, opts)
+
+        @test size(processed.curves, 1) == 2          # collapsed to 2 unique labels
+        @test processed.labels == ["A", "B"]
+        @test processed.curves[1, :] ≈ mean(rep_curves[1:2, :], dims=1)[:]
+        @test processed.curves[2, :] ≈ mean(rep_curves[3:4, :], dims=1)[:]
+    end
+
+    @testset "Replicate averaging drops 'b' and 'X' wells" begin
+        rep_curves = vcat(curves[1:2, :], curves[3:4, :], curves[5:5, :])
+        rep_labels = ["A", "A", "b", "X", "B"]
+        rep_data   = GrowthData(rep_curves, times, rep_labels)
+
+        opts = FitOptions(average_replicates=true)
+        processed = preprocess(rep_data, opts)
+
+        @test processed.labels == ["A", "B"]
+        @test size(processed.curves, 1) == 2
+    end
+
+    @testset "Replicate averaging is a no-op when disabled" begin
+        opts = FitOptions(average_replicates=false)
+        processed = preprocess(data, opts)
+        @test processed.curves ≈ data.curves
+        @test processed.labels == data.labels
+    end
+
     @testset "Clustering assigns cluster ids" begin
         opts = FitOptions(cluster=true, n_clusters=2, cluster_trend_test=false)
         processed = preprocess(data, opts)


### PR DESCRIPTION
Add average_replicates::Bool to FitOptions. When true, curves sharing the same label are averaged into a single row before any other step. Wells labelled "b" or "X" are excluded and dropped from output. This matches the biological convention of treating same-label wells as technical replicates of a single condition.