### PR TITLE
feat: add boxcar (symmetric moving-average) smoothing method

### DIFF
--- a/src/api/preprocessing.jl
+++ b/src/api/preprocessing.jl
@@ -145,6 +145,10 @@ function _apply_smoothing(
         return _apply_gaussian_smoothing(curves, times, opts)
     end
 
+    if opts.smooth_method == :boxcar
+        return _apply_boxcar_smoothing(curves, times, opts)
+    end
+
     smoothing_str = _smoothing_symbol_to_string(opts.smooth_method)
     n_curves = size(curves, 1)
 
@@ -187,6 +191,41 @@ _smoothing_symbol_to_string(s::Symbol) = Dict(
     :rolling_avg => "rolling_avg",
     :none        => "NO",
 )[s]
+
+# ---------------------------------------------------------------------------
+# Boxcar (symmetric moving average) smoothing
+# Keeps the original time grid; each point is replaced by the mean of the
+# symmetric window [j-half, j+half], clamped at the array boundaries.
+# ---------------------------------------------------------------------------
+
+"""
+    _apply_boxcar_smoothing(curves, times, opts) -> (Matrix{Float64}, Vector{Float64})
+
+Apply a centered boxcar (symmetric moving-average) filter to every curve.
+Unlike `:rolling_avg`, the time grid is unchanged and no points are dropped.
+Window width is `opts.boxcar_window` (must be ≥ 1).
+"""
+function _apply_boxcar_smoothing(
+    curves::Matrix{Float64},
+    times::Vector{Float64},
+    opts::FitOptions,
+)::Tuple{Matrix{Float64}, Vector{Float64}}
+    w = max(1, opts.boxcar_window)
+    half = w ÷ 2
+    n_curves, n_tp = size(curves)
+    smoothed = Matrix{Float64}(undef, n_curves, n_tp)
+
+    for i in 1:n_curves
+        curve = @view curves[i, :]
+        for j in 1:n_tp
+            lo = max(1, j - half)
+            hi = min(n_tp, j + half)
+            smoothed[i, j] = mean(@view curve[lo:hi])
+        end
+    end
+
+    return smoothed, times   # time grid is preserved
+end
 
 # ---------------------------------------------------------------------------
 # Gaussian kernel smoothing (no external dependencies)

--- a/src/api/types.jl
+++ b/src/api/types.jl
@@ -80,8 +80,11 @@ Every field has a sensible default so users only override what they need.
 
 # Preprocessing fields
 - `smooth::Bool = false`: apply smoothing before fitting.
-- `smooth_method::Symbol = :lowess`: `:lowess`, `:rolling_avg`, `:gaussian`, or `:none`.
+- `smooth_method::Symbol = :lowess`: `:lowess`, `:rolling_avg`, `:gaussian`, `:boxcar`, or `:none`.
 - `smooth_pt_avg::Int = 7`: window size for `:rolling_avg`.
+- `boxcar_window::Int = 5`: half-width of the symmetric boxcar filter (`:boxcar` method).
+  Each point is averaged over `[j - boxcar_window÷2, j + boxcar_window÷2]`. The original
+  time grid is preserved (no points dropped).
 - `lowess_frac::Float64 = 0.05`: bandwidth fraction for `:lowess`.
 - `gaussian_h_mult::Float64 = 2.0`: bandwidth multiplier for Gaussian smoothing
   (bandwidth = `gaussian_h_mult × median(Δt)`).
@@ -132,6 +135,7 @@ Every field has a sensible default so users only override what they need.
     smooth::Bool                = false
     smooth_method::Symbol       = :lowess
     smooth_pt_avg::Int          = 7
+    boxcar_window::Int          = 5
     lowess_frac::Float64        = 0.05
     gaussian_h_mult::Float64    = 2.0
     gaussian_time_grid::Union{Nothing, Vector{Float64}} = nothing

--- a/test/api/test_preprocessing.jl
+++ b/test/api/test_preprocessing.jl
@@ -39,6 +39,16 @@
         @test size(processed.curves, 2) <= size(data.curves, 2)
     end
 
+    @testset "Smoothing (boxcar) preserves shape and time grid" begin
+        opts = FitOptions(smooth=true, smooth_method=:boxcar, boxcar_window=3)
+        processed = preprocess(data, opts)
+        # boxcar is length-preserving: shape and times identical to input
+        @test size(processed.curves) == size(data.curves)
+        @test processed.times == data.times
+        # smoothing must change at least some values
+        @test processed.curves != data.curves
+    end
+
     @testset "Smoothing (gaussian) keeps original times when no grid given" begin
         opts = FitOptions(smooth=true, smooth_method=:gaussian, gaussian_h_mult=2.0)
         processed = preprocess(data, opts)


### PR DESCRIPTION
Add smooth_method=:boxcar to the preprocessing pipeline. Unlike :rolling_avg, the boxcar filter is symmetric around each point and preserves the original time grid (no points dropped). Window width is controlled by boxcar_window::Int (default 5).