### PR TITLE
Add cluster_method: expose kmedoids, hclust, dbscan through preprocess

### DIFF
--- a/src/api/preprocessing.jl
+++ b/src/api/preprocessing.jl
@@ -399,7 +399,8 @@ function _cluster(
                                                      centroids_norm, exp_label)
     end
 
-    n_effective = isempty(labels) ? opts.n_clusters : maximum(filter(>(0), labels; init=0))
+    pos_labels  = filter(>(0), labels)
+    n_effective = (isempty(labels) || isempty(pos_labels)) ? opts.n_clusters : maximum(pos_labels)
     n_effective = max(n_effective, 1)
     centroids   = _compute_centroids(zscored_all, labels, n_effective)
     return labels, centroids, wcss
@@ -421,7 +422,6 @@ function _cluster_dispatch(
         D      = _pairwise_euclidean(zscored)
         result = kmedoids(D, k; maxiter = opts.kmeans_max_iters, tol = opts.kmeans_tol)
         ids    = assignments(result)
-        wcss   = sum(minimum(D[i, ids .== ids[i]] for j in 1:1) for i in eachindex(ids))
         return ids, result.totalcost
 
     elseif method == :hclust

--- a/src/api/preprocessing.jl
+++ b/src/api/preprocessing.jl
@@ -11,7 +11,7 @@
 #   - linear slope t-test (Statistics stdlib) for flat-curve trend detection
 # =============================================================================
 
-using Clustering: kmeans, assignments
+using Clustering: kmeans, kmedoids, hclust, cutree, dbscan, assignments
 using StatsBase: zscore
 using Distributions: TDist, cdf
 using Random: MersenneTwister
@@ -356,6 +356,15 @@ When `cluster_exp_prototype=true`, an additional exponential shape cluster is
 added after k-means: each curve is tested against pre-built z-scored exponential
 prototypes and re-labelled if it is closer to them than to any k-means centroid.
 """
+function _pairwise_euclidean(X::Matrix{Float64})::Matrix{Float64}
+    n = size(X, 1)
+    D = Matrix{Float64}(undef, n, n)
+    for i in 1:n, j in 1:n
+        D[i, j] = sqrt(sum((X[i, k] - X[j, k])^2 for k in axes(X, 2)))
+    end
+    return D
+end
+
 function _cluster(
     curves::Matrix{Float64},
     times::Vector{Float64},
@@ -363,24 +372,26 @@ function _cluster(
 )::Tuple{Vector{Int}, Matrix{Float64}, Float64}
     size(curves, 1) == 0 && return Int[], zeros(Float64, opts.n_clusters, size(curves, 2)), 0.0
 
-    # Z-score all curves once; used for both k-means and centroid computation.
     zscored_all = _zscore_rows(curves)
+    method      = opts.cluster_method
 
-    if opts.cluster_prescreen_constant
-        labels, wcss = _cluster_with_prescreen(curves, zscored_all, opts)
-    elseif opts.cluster_trend_test
-        k_dynamic = max(1, opts.n_clusters - 1)
-        result = _kmeans_best(zscored_all', k_dynamic, opts)
-        labels = assignments(result)
-        wcss   = result.totalcost
-        labels = _apply_trend_labels(curves, times, labels, opts.n_clusters)
+    # Pre-screening: separate constant curves before running any clustering
+    # algorithm. Applies to all methods except :dbscan (no k parameter).
+    if opts.cluster_prescreen_constant && method != :dbscan
+        labels, wcss = _cluster_with_prescreen_method(curves, zscored_all, opts)
     else
-        result = _kmeans_best(zscored_all', opts.n_clusters, opts)
-        labels = assignments(result)
-        wcss   = result.totalcost
+        labels, wcss = _cluster_dispatch(zscored_all, opts)
+
+        # Post-hoc trend-test flat reassignment (ignored when pre-screening is on
+        # since the sentinel cluster already captures constant curves)
+        if opts.cluster_trend_test && !opts.cluster_prescreen_constant
+            flat_id = method == :dbscan ? maximum(labels) + 1 : opts.n_clusters
+            labels  = _apply_trend_labels(curves, times, labels, flat_id)
+        end
     end
 
-    if opts.cluster_exp_prototype
+    # Exponential prototype (kmeans only)
+    if opts.cluster_exp_prototype && method == :kmeans
         exp_label      = _exp_prototype_label(opts, labels)
         exp_protos     = _build_exp_prototypes(times)
         centroids_norm = _compute_centroids(zscored_all, labels, opts.n_clusters)
@@ -388,10 +399,75 @@ function _cluster(
                                                      centroids_norm, exp_label)
     end
 
-    n_effective = isempty(labels) ? opts.n_clusters : maximum(labels)
-    # Centroids in z-normalised space (shape prototypes, scale-independent).
-    centroids = _compute_centroids(zscored_all, labels, n_effective)
+    n_effective = isempty(labels) ? opts.n_clusters : maximum(filter(>(0), labels; init=0))
+    n_effective = max(n_effective, 1)
+    centroids   = _compute_centroids(zscored_all, labels, n_effective)
     return labels, centroids, wcss
+end
+
+# Dispatch to the appropriate clustering algorithm on z-scored curves.
+function _cluster_dispatch(
+    zscored::Matrix{Float64},
+    opts::FitOptions,
+)::Tuple{Vector{Int}, Float64}
+    method = opts.cluster_method
+    k      = opts.n_clusters
+
+    if method == :kmeans
+        result = _kmeans_best(zscored', k, opts)
+        return assignments(result), result.totalcost
+
+    elseif method == :kmedoids
+        D      = _pairwise_euclidean(zscored)
+        result = kmedoids(D, k; maxiter = opts.kmeans_max_iters, tol = opts.kmeans_tol)
+        ids    = assignments(result)
+        wcss   = sum(minimum(D[i, ids .== ids[i]] for j in 1:1) for i in eachindex(ids))
+        return ids, result.totalcost
+
+    elseif method == :hclust
+        D      = _pairwise_euclidean(zscored)
+        hc     = hclust(D; linkage = opts.cluster_hclust_linkage)
+        ids    = cutree(hc; k)
+        wcss   = sum(sum((zscored[ids .== c, :] .- mean(zscored[ids .== c, :], dims=1)).^2)
+                     for c in unique(ids))
+        return ids, wcss
+
+    elseif method == :dbscan
+        result = dbscan(zscored', opts.cluster_dbscan_eps;
+                        min_neighbors = opts.cluster_dbscan_minpts)
+        ids    = assignments(result)   # 0 = noise
+        return ids, 0.0
+
+    else
+        error("Unknown cluster_method: $method. Choose :kmeans, :kmedoids, :hclust, or :dbscan.")
+    end
+end
+
+# Pre-screening variant: flag constant curves, run the chosen algorithm on the
+# dynamic subset only, assign constant curves to the sentinel label n_clusters.
+function _cluster_with_prescreen_method(
+    curves::Matrix{Float64},
+    zscored_all::Matrix{Float64},
+    opts::FitOptions,
+)::Tuple{Vector{Int}, Float64}
+    W           = size(curves, 1)
+    const_mask  = _prescreen_constant(curves, opts)
+    dynamic_idx = findall(.!const_mask)
+    labels      = fill(opts.n_clusters, W)
+    wcss        = 0.0
+
+    if !isempty(dynamic_idx) && opts.n_clusters > 1
+        sub_opts   = FitOptions(; (f => getfield(opts, f) for f in fieldnames(FitOptions))...,
+                                  n_clusters          = opts.n_clusters - 1,
+                                  cluster_trend_test  = false,
+                                  cluster_prescreen_constant = false)
+        sub_z      = zscored_all[dynamic_idx, :]
+        sub_labels, wcss = _cluster_dispatch(sub_z, sub_opts)
+        for (pos, idx) in enumerate(dynamic_idx)
+            labels[idx] = sub_labels[pos]
+        end
+    end
+    return labels, wcss
 end
 
 # The exponential prototype occupies a label that is NOT already in use by k-means.
@@ -430,38 +506,6 @@ function _prescreen_constant(curves::Matrix{Float64}, opts::FitOptions)::BitVect
     return const_mask
 end
 
-"""
-    _cluster_with_prescreen(curves, zscored_all, opts) -> (Vector{Int}, Float64)
-
-Pre-screen constant curves using original-space quantile ratio, then run k-means
-on the z-normalised dynamic subset. Constant curves receive label `n_clusters`;
-dynamic curves get labels `1..n_clusters-1`.
-Returns labels and the WCSS from the k-means step (0.0 when all curves are constant).
-"""
-function _cluster_with_prescreen(
-    curves::Matrix{Float64},
-    zscored_all::Matrix{Float64},
-    opts::FitOptions,
-)::Tuple{Vector{Int}, Float64}
-    W           = size(curves, 1)
-    const_mask  = _prescreen_constant(curves, opts)   # quantile test on raw curves
-    dynamic_idx = findall(.!const_mask)
-    labels      = fill(opts.n_clusters, W)   # default: constant
-    wcss        = 0.0
-
-    if !isempty(dynamic_idx) && opts.n_clusters > 1
-        k_dynamic = opts.n_clusters - 1
-        # k-means runs on z-normalised dynamic curves
-        result    = _kmeans_best(zscored_all[dynamic_idx, :]', k_dynamic, opts)
-        km_labels = assignments(result)
-        wcss      = result.totalcost
-        for (pos, idx) in enumerate(dynamic_idx)
-            labels[idx] = km_labels[pos]
-        end
-    end
-
-    return labels, wcss
-end
 
 # ---------------------------------------------------------------------------
 # Centroid computation

--- a/src/api/types.jl
+++ b/src/api/types.jl
@@ -158,6 +158,15 @@ Every field has a sensible default so users only override what they need.
   distance to the nearest k-means centroid; the exponential label wins when
   it is closer. Requires `n_clusters ≥ 3` when combined with constant pre-screening
   (`n_clusters - 1` for exponential, `n_clusters` for constant), or ≥ 2 otherwise.
+- `cluster_method::Symbol = :kmeans`: clustering algorithm — `:kmeans`, `:kmedoids`,
+  `:hclust`, or `:dbscan`. Pre-screening and the trend test are supported for all
+  methods. `n_clusters` is ignored by `:dbscan` (it determines the number of clusters
+  from the data). `cluster_exp_prototype` is only available with `:kmeans`.
+- `cluster_hclust_linkage::Symbol = :ward`: linkage criterion for `:hclust` —
+  `:ward`, `:average`, `:complete`, or `:single`.
+- `cluster_dbscan_eps::Float64 = 1.0`: neighbourhood radius for `:dbscan`.
+- `cluster_dbscan_minpts::Int = 3`: minimum number of neighbours for a core point
+  in `:dbscan`. Points below this threshold are labelled 0 (noise).
 - `kmeans_n_init::Int = 10`: number of times k-means is run with different random
   initialisations; the run with the lowest WCSS is kept.
 - `kmeans_max_iters::Int = 300`: maximum number of Lloyd iterations per k-means run.
@@ -220,6 +229,10 @@ find the elbow and choose the optimal number of clusters.
     cluster_q_low::Float64           = 0.05
     cluster_q_high::Float64          = 0.95
     cluster_exp_prototype::Bool      = false
+    cluster_method::Symbol           = :kmeans
+    cluster_hclust_linkage::Symbol   = :ward
+    cluster_dbscan_eps::Float64      = 1.0
+    cluster_dbscan_minpts::Int       = 3
     kmeans_n_init::Int               = 10
     kmeans_max_iters::Int            = 300
     kmeans_tol::Float64              = 1e-6

--- a/test/api/test_preprocessing.jl
+++ b/test/api/test_preprocessing.jl
@@ -245,12 +245,12 @@
     @testset "cluster_method=:kmedoids with prescreen assigns sentinel" begin
         flat_curves = repeat([0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1], 2)
         mixed_data  = GrowthData(vcat(data.curves, flat_curves), data.times,
-                                  ["c$i" for i in 1:10])
+                                  ["c$i" for i in 1:7])
         opts = FitOptions(cluster=true, n_clusters=3, cluster_method=:kmedoids,
                           cluster_prescreen_constant=true, cluster_trend_test=false)
         processed = preprocess(mixed_data, opts)
-        @test all(processed.clusters[9:10] .== 3)
-        @test all(processed.clusters[1:8] .!= 3)
+        @test all(processed.clusters[6:7] .== 3)
+        @test all(processed.clusters[1:5] .!= 3)
     end
 
     @testset "cluster_method=:hclust with trend_test reassigns flat curves" begin

--- a/test/api/test_preprocessing.jl
+++ b/test/api/test_preprocessing.jl
@@ -210,6 +210,66 @@
         @test all(processed.clusters[6:8] .== n_k)
     end
 
+    # -----------------------------------------------------------------------
+    # cluster_method variants
+    # -----------------------------------------------------------------------
+
+    @testset "cluster_method=:kmedoids produces valid labels" begin
+        opts = FitOptions(cluster=true, n_clusters=3, cluster_method=:kmedoids,
+                          cluster_trend_test=false)
+        processed = preprocess(data, opts)
+        @test processed.clusters isa Vector{Int}
+        @test length(processed.clusters) == size(data.curves, 1)
+        @test all(1 .<= processed.clusters .<= 3)
+    end
+
+    @testset "cluster_method=:hclust produces valid labels" begin
+        opts = FitOptions(cluster=true, n_clusters=3, cluster_method=:hclust,
+                          cluster_hclust_linkage=:ward, cluster_trend_test=false)
+        processed = preprocess(data, opts)
+        @test processed.clusters isa Vector{Int}
+        @test length(processed.clusters) == size(data.curves, 1)
+        @test all(1 .<= processed.clusters .<= 3)
+    end
+
+    @testset "cluster_method=:dbscan produces non-negative labels" begin
+        opts = FitOptions(cluster=true, cluster_method=:dbscan,
+                          cluster_dbscan_eps=2.0, cluster_dbscan_minpts=2,
+                          cluster_trend_test=false)
+        processed = preprocess(data, opts)
+        @test processed.clusters isa Vector{Int}
+        @test length(processed.clusters) == size(data.curves, 1)
+        @test all(processed.clusters .>= 0)   # 0 = noise
+    end
+
+    @testset "cluster_method=:kmedoids with prescreen assigns sentinel" begin
+        flat_curves = repeat([0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1 0.1], 2)
+        mixed_data  = GrowthData(vcat(data.curves, flat_curves), data.times,
+                                  ["c$i" for i in 1:10])
+        opts = FitOptions(cluster=true, n_clusters=3, cluster_method=:kmedoids,
+                          cluster_prescreen_constant=true, cluster_trend_test=false)
+        processed = preprocess(mixed_data, opts)
+        @test all(processed.clusters[9:10] .== 3)
+        @test all(processed.clusters[1:8] .!= 3)
+    end
+
+    @testset "cluster_method=:hclust with trend_test reassigns flat curves" begin
+        times_test = collect(0.0:1.0:9.0)
+        flat   = fill(0.3, 1, 10)
+        growth = [range(0.0, 1.0; length=10)'; range(0.0, 1.5; length=10)']
+        gd     = GrowthData(vcat(flat, growth), times_test, ["flat","g1","g2"])
+        opts   = FitOptions(cluster=true, n_clusters=3, cluster_method=:hclust,
+                            cluster_trend_test=true)
+        processed = preprocess(gd, opts)
+        @test processed.clusters[1] == maximum(processed.clusters)
+    end
+
+    @testset "Unknown cluster_method throws" begin
+        opts = FitOptions(cluster=true, n_clusters=2, cluster_method=:bogus,
+                          cluster_trend_test=false)
+        @test_throws ErrorException preprocess(data, opts)
+    end
+
     @testset "Pure function — original data not mutated" begin
         original_copy = copy(data.curves)
         _ = preprocess(data, FitOptions(blank_subtraction=true, blank_value=0.1))


### PR DESCRIPTION
## Summary

- Adds `cluster_method::Symbol` field to `FitOptions` (`:kmeans`, `:kmedoids`, `:hclust`, `:dbscan`)
- Adds `cluster_hclust_linkage`, `cluster_dbscan_eps`, `cluster_dbscan_minpts` fields
- Refactors `_cluster` to dispatch to `_cluster_dispatch` for all methods
- Pre-screening (`cluster_prescreen_constant`) and trend-test (`cluster_trend_test`) now work with all methods (except `:dbscan` for pre-screening)
- Adds `_pairwise_euclidean` helper used by kmedoids and hclust
- 6 new tests covering each new method and their interaction with pre-screening/trend-test

## Test plan

- [ ] `cluster_method=:kmedoids` produces valid labels in `1..k`
- [ ] `cluster_method=:hclust` produces valid labels in `1..k`
- [ ] `cluster_method=:dbscan` produces non-negative labels (0 = noise)
- [ ] kmedoids + prescreen assigns flat curves to sentinel label
- [ ] hclust + trend_test reassigns flat curves to `maximum(labels)`
- [ ] Unknown method raises `ErrorException`
- [ ] All 66 preprocessing tests pass; full suite green