### PR TITLE
fix: use conventional Gaussian-likelihood AICc for model selection

### DIFF
--- a/src/api/fitting.jl
+++ b/src/api/fitting.jl
@@ -202,8 +202,12 @@ function _fit_single(
     loss_val     = Float64(res_param[end])
     params_raw   = res_param[4:end-3]     # strip metadata columns
     n_params     = length(p0)
-    aic          = AICc_evaluation2(n_params, 2.0, fit_times, loss_val;
-                                    correction = opts.aic_correction)
+    # Gaussian-likelihood AICc from the residuals of the fitted curve against the
+    # (already preprocessed) observed OD, rather than the raw fitting loss, so the
+    # reported/compared value is the conventional AICc shown in the manuscript.
+    obs_od       = length(fitted_curve) == size(data_mat, 2) ? data_mat[2, :] : fitted_curve
+    aic          = AICc_evaluation(n_params, 2.0, obs_od, fitted_curve;
+                                   correction = opts.aic_correction)
 
     return (
         model_name   = model.name,
@@ -254,8 +258,10 @@ function _fit_single(
     loss_val     = Float64(res_param[end])
     params_raw   = res_param[3]           # Vector of fitted parameters
     n_params     = length(p0)
-    aic          = AICc_evaluation2(n_params, 2.0, fit_times, loss_val;
-                                    correction = opts.aic_correction)
+    # Gaussian-likelihood AICc from the fitted-curve residuals (see NL branch).
+    obs_od       = length(fitted_curve) == size(data_mat, 2) ? data_mat[2, :] : fitted_curve
+    aic          = AICc_evaluation(n_params, 2.0, obs_od, fitted_curve;
+                                   correction = opts.aic_correction)
 
     return (
         model_name   = model.name,

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -680,34 +680,40 @@ end
 
 
 function AICc_evaluation(n_param, beta_smoothing_ms, data, data_th; correction=true)
+    # Conventional small-sample-corrected AIC under a Gaussian error model, as
+    # displayed in the GUIbiont/Kinbiont manuscript:
+    #
+    #   AICc = 2p - 2 log(L_hat) + 2 p (p + 1) / (n - p - 1)
+    #
+    # with the MLE-variance Gaussian deviance
+    #
+    #   -2 log(L_hat) = n log(RSS / n) + n (log(2*pi) + 1),   RSS = sum (fit - obs)^2.
+    #
+    # `beta_smoothing_ms` scales both the parameter penalty and the correction
+    # term (beta = 2 reproduces the displayed 2p and 2 p (p+1)/(n-p-1) exactly).
+    # `data` is the observed series and `data_th` the fitted (theoretical) one.
+    data   = vec(collect(data))
+    data_th = vec(collect(data_th))
     n_data = length(data)
 
-
-    if n_data == length(data_th)
-        if n_data > n_param - 2
-            # RSS = sum(abs.(data_th .- data ) .^ 2)
-            RSS = sum(abs.(data_th .- data) .^ 2)
-
-            println(n_param)
-            println(RSS)
-            println(log(RSS / n_data))
-            if correction == true
-                correction_value = beta_smoothing_ms * (((n_param + 1) * (n_param + 2)) / (n_data - n_param - 2))
-            else
-                correction_value = 0.0
-            end
-            AIC = +beta_smoothing_ms * n_param + n_data * log(RSS / n_data)
-            AICc = AIC + correction_value
-        else
-            AICc = 10^9
-
-        end
-    else
-        AICc = 10^9
-
-
+    # A positive small-sample denominator (n - p - 1 > 0) is required for the
+    # correction and for a well-defined Gaussian log-likelihood.
+    if n_data != length(data_th) || n_data <= n_param + 1
+        return 10^9
     end
-    println(AICc)
+
+    RSS = sum(abs.(data_th .- data) .^ 2)
+    RSS = max(RSS, 1e-300)   # guard against a perfect fit (RSS == 0 -> -Inf)
+
+    neg2logL = n_data * log(RSS / n_data) + n_data * (log(2 * pi) + 1)
+
+    if correction == true
+        correction_value = beta_smoothing_ms * ((n_param * (n_param + 1)) / (n_data - n_param - 1))
+    else
+        correction_value = 0.0
+    end
+
+    AICc = beta_smoothing_ms * n_param + neg2logL + correction_value
 
     return AICc
 

--- a/test/api/test_vs_legacy.jl
+++ b/test/api/test_vs_legacy.jl
@@ -107,15 +107,18 @@
             type_of_loss = "RE",
             smoothing    = false,
         )
-        old_loss  = Float64(raw_nl[2][end])
-        old_times = Vector{Float64}(raw_nl[4])
-        old_aic   = Kinbiont.AICc_evaluation2(length(p0), 2.0, old_times, old_loss;
-                                              correction=true)
+        old_curve_nl = Vector{Float64}(raw_nl[3])
+        # The API reports a Gaussian-likelihood AICc computed from the residuals
+        # of the fitted curve against the observed data (the manuscript formula),
+        # not the raw fitting loss. Expected value uses the fitted curve vs `curve`.
+        expected_aic = Kinbiont.AICc_evaluation(length(p0), 2.0, curve, old_curve_nl;
+                                                correction=true)
 
         Random.seed!(7)
         spec_nl = ModelSpec([MODEL_REGISTRY["NL_logistic"]], [p0])
         res_nl  = kinbiont_fit(data_g, spec_nl, FitOptions(loss="RE"))
 
-        @test res_nl[1].best_aic == Float64(old_aic)
+        @test res_nl[1].fitted_curve == old_curve_nl
+        @test res_nl[1].best_aic == Float64(expected_aic)
     end
 end


### PR DESCRIPTION
## Summary

Kinbiont reported and selected parametric growth models on

```
2p + n·log(loss) + 2(p+1)(p+2)/(n−p−2)
```

where `loss` is the raw fitting objective (relative error, `1−ρ`, …) — **not** a likelihood. Despite being labelled AICc, this is not the conventional corrected AIC, so both the reported values and the best-model selection were computed on a non-likelihood score.

This PR computes the conventional small-sample-corrected **Gaussian-likelihood AICc** from the residuals of the fitted curve against the observed OD:

```
AICc      = 2p − 2·log L̂ + 2p(p+1)/(n−p−1)
−2·log L̂ = n·log(RSS/n) + n·(log(2π) + 1),   RSS = Σ (fit − obs)²
```

## Changes

- **`src/functions.jl` — `AICc_evaluation`**: implement the formula above (the function was previously dead code); guard `n ≤ p+1` and `RSS = 0`.
- **`src/api/fitting.jl` — `_fit_single` (NL and ODE branches)**: compute AICc from `fitted_curve` vs `data_mat[2,:]` instead of the raw `loss`. Since `kinbiont_fit` selects the best model via `argmin` over each candidate's `.aic`, this fixes both the reported AICc **and** model selection.
- **`test/api/test_vs_legacy.jl`**: the "AICc consistency" test previously asserted the old loss-based value; updated to assert the new Gaussian-likelihood contract (computed from the fitted curve vs observed data).

SINDy/change-point AICc paths (`api/fitting.jl:336,453`, which use `1−ρ` / `rss/N`) are intentionally left unchanged — they are not Gaussian growth-model selection.

## Scope

Orthogonal to `feat/guibiont-preprocessing-parity` (that branch touches `batch.jl`/`preprocessing.jl`/`clustering_helpers.jl`; this one only `functions.jl`/`api/fitting.jl`), so it applies cleanly regardless of merge order.

## Test plan

- [x] `AICc_evaluation` output matches the manuscript formula exactly (unit-checked against a hand computation, `isapprox atol=1e-9`).
- [x] `test_vs_legacy.jl`, `test_fitting.jl`, `test_preprocessing.jl` pass (159/159).
- [x] End-to-end parametric fit + model selection runs; reported AICc is on the Gaussian-likelihood scale.
- [ ] Full `Pkg.test()` — could **not** complete in the dev environment due to a `SymbolicRegression` precompilation issue (an environment/precompile problem, **not** a test failure). Please confirm CI runs the full suite.

