### PR TITLE
feat: GUIbiont preprocessing parity + mu-based stationary Nmax (rebased on main)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,7 @@ jobs:
           version: ${{ matrix.julia-version }}
       - uses: julia-actions/cache@v2
       - name: Install dependencies
-        run: julia --project=. -e 'using Pkg; Pkg.add(name="DynamicQuantities", version="1.11.0"); Pkg.instantiate()'
+        run: julia --project=. -e 'using Pkg; Pkg.instantiate()'
       - name: Load package
         run: julia --project=. -e 'using Kinbiont; println("Kinbiont loaded OK")'
       - name: Run tests

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -20,7 +20,7 @@ jobs:
           version: '1'
       - uses: julia-actions/cache@v2
       - name: Install dependencies
-        run: julia --project=. -e 'using Pkg; Pkg.add(name="DynamicQuantities", version="1.11.0"); Pkg.instantiate()'
+        run: julia --project=. -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy
         run: julia --project=. --color=yes docs/make_local.jl
       - name: Setup Pages

--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ version = "1.4.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
-BetaML = "024491cd-cc6b-443e-8034-08ea7eb7db2b"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 Catalyst = "479239e8-5488-4da2-87a7-35f2df7eef83"
 ChangePointDetection = "68f453bf-a161-50e8-aafe-8ad75c8d6944"
@@ -55,7 +54,6 @@ KinbiontDataDrivenExt = ["DataDrivenDiffEq", "DataDrivenSparse", "ModelingToolki
 
 [compat]
 AbstractTrees = "0.4.5"
-BetaML = "0.12.1"
 CSV = "0.10.15"
 Catalyst = "14.4.1"
 ChangePointDetection = "1.2.0"

--- a/docs/src/01_install/index.md
+++ b/docs/src/01_install/index.md
@@ -41,7 +41,6 @@ using Kinbiont
 
 - **Julia**: (>1.10)
 - **AbstractTrees**: 0.4.5
-- **BetaML**: 0.12.0
 - **CSV**: 0.10.14
 - **ChangePointDetection**: 1.2.0
 - **Combinatorics**: 1.0.2

--- a/src/api/batch.jl
+++ b/src/api/batch.jl
@@ -364,6 +364,35 @@ function _gui_batch_run_attempt(
     )
 end
 
+"""
+    loglin_stationary_nmax(raw; pt_smoothing_derivative=7) -> Float64
+
+Return the empirical maximum OD at the stationary cutoff associated with the
+log-linear `mu_max` stored in `raw`. The legacy q95 value in `raw[2][16]` is
+not used.
+"""
+function loglin_stationary_nmax(
+    raw;
+    pt_smoothing_derivative::Int=7,
+)::Float64
+    params = raw[2]
+    length(params) >= 7 && params[7] !== missing || return NaN
+    smoothed = raw[4]
+    ismissing(smoothed) && return NaN
+
+    opts = FitOptions(
+        stationary_percentile_thr=0.05,
+        stationary_pt_smooth_derivative=pt_smoothing_derivative,
+        stationary_win_size=5,
+        stationary_thr_od=0.02,
+    )
+    cutoff = find_stationary_cutoff_from_mu(
+        Matrix{Float64}(smoothed), Float64(params[7]), opts,
+    )
+    nmax = Float64(smoothed[2, cutoff])
+    return isfinite(nmax) ? nmax : NaN
+end
+
 function _gui_batch_loglin_fields(t, y, label, experiment; pt_avg=7, pt_deriv=7, pt_min_win=7, threshold=0.9)
     out = Dict{String, Any}(
         "gr_loglin" => NaN,
@@ -397,10 +426,12 @@ function _gui_batch_loglin_fields(t, y, label, experiment; pt_avg=7, pt_deriv=7,
             out["t_exp_end_loglin"] = Float64(params[4])
             out["doubling_time_loglin"] = Float64(params[9])
             out["R_squared_loglin"] = Float64(params[14])^2
-            if length(params) >= 16
+            if length(params) >= 15
                 out["lag_loglin"] = params[15] === missing ? NaN : Float64(params[15])
-                out["N_max_emp"] = params[16] === missing ? NaN : Float64(params[16])
             end
+            out["N_max_emp"] = loglin_stationary_nmax(
+                raw; pt_smoothing_derivative=pt_deriv,
+            )
             out["loglin_converged"] = true
         end
     catch
@@ -726,6 +757,7 @@ function _gui_batch_fit_loglin_one(
     threshold_of_exp::Float64=0.9,
     start_exp_win_thr::Float64=0.05,
     thr_lowess::Float64=0.05,
+    unblanked_floor::Float64=1e-4,
 )
     prepared = _gui_prepare_curve(
         od_raw;
@@ -733,7 +765,7 @@ function _gui_batch_fit_loglin_one(
         subtract_blank,
         blank_method,
         blank_timeseries,
-        unblanked_floor=1e-4,
+        unblanked_floor,
     )
     od_for_fit = prepared.od_for_fit
     od_subtracted_display = prepared.od_subtracted_display
@@ -770,8 +802,11 @@ function _gui_batch_fit_loglin_one(
         result["t_exp_end_loglin"] = Float64(params[4])
         result["doubling_time_loglin"] = Float64(params[9])
         result["R_squared_loglin"] = Float64(params[14])^2
-        result["lag_loglin"] = length(params) >= 16 && params[15] !== missing ? Float64(params[15]) : NaN
-        result["N_max_emp"] = length(params) >= 16 && params[16] !== missing ? Float64(params[16]) : NaN
+        result["lag_loglin"] = length(params) >= 15 && params[15] !== missing ? Float64(params[15]) : NaN
+        # Deliberately ignore legacy params[16] (curve q95).
+        result["N_max_emp"] = loglin_stationary_nmax(
+            raw; pt_smoothing_derivative,
+        )
         result["loglin_converged"] = true
     else
         for name in ["gr_loglin", "gr_loglin_se", "gr_max_sliding",
@@ -784,6 +819,83 @@ function _gui_batch_fit_loglin_one(
     end
     od_subtracted_display !== nothing && (result["experimental_od_subtracted"] = od_subtracted_display)
     return result
+end
+
+"""
+    kinbiont_fit_loglin(data::GrowthData; kwargs...) -> Dict
+
+Fit one growth curve with the log-linear method and return the same named
+fields used by GUIbiont, including the stationary-cutoff `N_max_emp`.
+"""
+function kinbiont_fit_loglin(
+    data::GrowthData;
+    experiment::String="experiment",
+    label::Union{Nothing, String}=nothing,
+    blank_subtraction::Bool=false,
+    blank_method::String="pointbypoint",
+    blank_value::Real=0.0,
+    blank_timeseries::Vector{Float64}=Float64[],
+    unblanked_floor::Float64=1e-4,
+    type_of_smoothing::String="rolling_avg",
+    pt_avg::Int=7,
+    pt_smoothing_derivative::Int=7,
+    pt_min_size_of_win::Int=7,
+    type_of_win::String="maximum",
+    threshold_of_exp::Float64=0.9,
+    start_exp_win_thr::Float64=0.05,
+    thr_lowess::Float64=0.05,
+)
+    selected_label = isnothing(label) ? only(data.labels) : label
+    idx = findfirst(==(selected_label), data.labels)
+    idx === nothing && throw(ArgumentError("Well '$selected_label' not found"))
+
+    t = data.times
+    y = vec(data.curves[idx, :])
+    valid = findall(i -> isfinite(t[i]) && isfinite(y[i]), eachindex(t))
+    min_pts = max(10, pt_smoothing_derivative + pt_min_size_of_win + 2)
+    length(valid) >= min_pts || throw(ArgumentError("Insufficient data points"))
+
+    blank_ts = isempty(blank_timeseries) ? Float64[] : Float64.(blank_timeseries[valid])
+    return _gui_batch_fit_loglin_one(
+        Float64.(t[valid]), Float64.(y[valid]), selected_label, experiment;
+        blank_value,
+        subtract_blank=blank_subtraction,
+        blank_method,
+        blank_timeseries=blank_ts,
+        unblanked_floor,
+        type_of_smoothing,
+        pt_avg,
+        pt_smoothing_derivative,
+        pt_min_size_of_win,
+        type_of_win,
+        threshold_of_exp,
+        start_exp_win_thr,
+        thr_lowess,
+    )
+end
+
+"""
+    kinbiont_fit_loglin(data, preprocess_opts::FitOptions; kwargs...) -> Dict
+
+Convenience overload that reuses the blank-correction settings from an
+existing `FitOptions` object.
+"""
+function kinbiont_fit_loglin(
+    data::GrowthData,
+    preprocess_opts::FitOptions;
+    kwargs...,
+)
+    blank_ts = isnothing(preprocess_opts.blank_timeseries) ?
+        Float64[] : preprocess_opts.blank_timeseries
+    return kinbiont_fit_loglin(
+        data;
+        blank_subtraction=preprocess_opts.blank_subtraction,
+        blank_method=String(preprocess_opts.blank_method),
+        blank_value=preprocess_opts.blank_value,
+        blank_timeseries=blank_ts,
+        unblanked_floor=preprocess_opts.negative_threshold,
+        kwargs...,
+    )
 end
 
 """
@@ -903,5 +1015,7 @@ end
 
 export kinbiont_batch_fit
 export save_gui_batch_results
+export loglin_stationary_nmax
+export kinbiont_fit_loglin
 export kinbiont_batch_loglin
 export save_gui_batch_loglin_results

--- a/src/api/batch.jl
+++ b/src/api/batch.jl
@@ -245,12 +245,12 @@ function _gui_batch_linear_interp(x, xs, ys)
     return Float64(last(ys))
 end
 
-function _gui_batch_loss_rmse(t, y, fit_t, fit_y, t_peak)
+function _gui_batch_loss_rmse(t, y, fit_t, fit_y, score_end)
     isempty(fit_t) && return Inf
     ss = 0.0
     n = 0
     for (i, ti) in enumerate(t)
-        (ti < first(fit_t) || ti > min(t_peak, last(fit_t))) && continue
+        (ti < first(fit_t) || ti > min(score_end, last(fit_t))) && continue
         pred = _gui_batch_linear_interp(ti, fit_t, fit_y)
         isfinite(pred) || continue
         ss += (y[i] - pred)^2
@@ -259,12 +259,43 @@ function _gui_batch_loss_rmse(t, y, fit_t, fit_y, t_peak)
     return n == 0 ? Inf : sqrt(ss / n)
 end
 
+function _gui_prepare_curve(
+    od_raw::Vector{Float64};
+    blank_value::Real=0.0,
+    subtract_blank::Bool=false,
+    blank_method::String="pointbypoint",
+    blank_timeseries::Vector{Float64}=Float64[],
+    unblanked_floor::Float64=0.01,
+)
+    if !(subtract_blank && blank_value > 0.0)
+        return (
+            od_for_fit=max.(od_raw, unblanked_floor),
+            od_subtracted_display=nothing,
+            anchor=od_raw[1],
+            shift=0.0,
+        )
+    end
+
+    pointwise = blank_method == "pointbypoint" && length(blank_timeseries) == length(od_raw)
+    blank_trace = pointwise ? blank_timeseries : fill(Float64(blank_value), length(od_raw))
+    method = blank_method == "clip" ? :clip : blank_method == "shift" ? :shift : :pointbypoint
+    corrected = pointwise ? od_raw .- blank_trace : od_raw .- blank_value
+    od_for_fit = vec(apply_blank_timeseries(
+        reshape(od_raw, 1, :), blank_trace; method, floor=1e-4,
+    ))
+
+    return (
+        od_for_fit=od_for_fit,
+        od_subtracted_display=max.(corrected, 0.0),
+        anchor=max(corrected[1], 0.0),
+        shift=method == :clip ? 0.0 : od_for_fit[1] - corrected[1],
+    )
+end
+
 function _gui_batch_run_attempt(
     optimizer::String,
     time_numeric::Vector{Float64},
     od_for_fit::Vector{Float64},
-    t_peak::Float64,
-    anchor::Float64,
     shift::Float64,
     subtract_blank::Bool,
     blank_value::Real,
@@ -273,16 +304,11 @@ function _gui_batch_run_attempt(
     model_names::Vector{String},
     maxiters::Int,
     abstol::Float64,
+    smooth::Bool,
+    smooth_window::Int,
 )
-    needs_smoothing = uppercase(optimizer) in ("BOBYQA", "LN_BOBYQA")
-    if needs_smoothing
-        time_fit = time_numeric
-        od_fit = od_for_fit
-    else
-        cut_idx = argmax(od_for_fit)
-        time_fit = time_numeric[1:cut_idx]
-        od_fit = od_for_fit[1:cut_idx]
-    end
+    time_fit = time_numeric
+    od_fit = od_for_fit
 
     model_keys = isempty(model_names) ? [model_name] : filter(!=("log_lin"), model_names)
     isempty(model_keys) && error("No parametric models selected")
@@ -293,11 +319,11 @@ function _gui_batch_run_attempt(
     upper = Union{Nothing, Vector{Float64}}[b[2] for b in bounds]
     spec = ModelSpec(models, initial_params; lower=lower, upper=upper)
     opt_params = abstol > 0.0 ? (maxiters=maxiters, abstol=abstol) : (maxiters=maxiters,)
-    opts = needs_smoothing ? FitOptions(
+    opts = FitOptions(
         scattering_correction=false,
-        smooth=true,
-        smooth_method=:rolling_avg,
-        smooth_pt_avg=14,
+        smooth=smooth,
+        smooth_method=:boxcar,
+        boxcar_window=smooth_window,
         cut_stationary_phase=true,
         stationary_percentile_thr=0.05,
         stationary_pt_smooth_derivative=10,
@@ -305,41 +331,35 @@ function _gui_batch_run_attempt(
         loss="RE",
         optimizer=_gui_batch_optimizer(optimizer),
         opt_params=opt_params,
-    ) : FitOptions(
-        scattering_correction=false,
-        smooth=false,
-        cut_stationary_phase=false,
-        loss="RE",
-        optimizer=_gui_batch_optimizer(optimizer),
-        opt_params=opt_params,
     )
 
-    r = kinbiont_fit(GrowthData(reshape(od_fit, 1, :), time_fit, [label]), spec, opts)[1]
+    fit_results = kinbiont_fit(GrowthData(reshape(od_fit, 1, :), time_fit, [label]), spec, opts)
+    r = fit_results[1]
+    preprocessed_time = Float64.(fit_results.data.times)
+    preprocessed_od = Float64.(vec(fit_results.data.curves[1, :]))
     fit_od_curve = subtract_blank && blank_value > 0.0 ? r.fitted_curve .- shift : r.fitted_curve
     fit_time_out = collect(r.times)
     fit_od_out = collect(fit_od_curve)
 
-    fit_start_idx = argmin(abs.(time_fit .- fit_time_out[1]))
-    if fit_start_idx > 1
-        fit_time_out = vcat(time_fit[1:fit_start_idx-1], fit_time_out)
-        fit_od_out = vcat(fill(anchor, fit_start_idx - 1), fit_od_out)
-    end
-
-    crop_idx = findlast(t -> t <= t_peak, fit_time_out)
-    if crop_idx !== nothing && crop_idx < length(fit_time_out)
-        fit_time_out = fit_time_out[1:crop_idx]
-        fit_od_out = fit_od_out[1:crop_idx]
-    end
-
-    fit_for_loss = subtract_blank && blank_value > 0.0 ? Float64.(fit_od_out) .+ shift : Float64.(fit_od_out)
+    stationary_phase_start = Float64(last(r.times))
+    preprocessed_od_out = subtract_blank && blank_value > 0.0 ? preprocessed_od .- shift : preprocessed_od
     return (
         best_params=r.best_params,
         param_names=r.best_model.param_names,
         model_name=_gui_batch_model_name(r.best_model),
         fit_time_out=fit_time_out,
         fit_od_out=fit_od_out,
+        preprocessed_time=preprocessed_time,
+        preprocessed_od=preprocessed_od_out,
+        stationary_phase_start=stationary_phase_start,
         aic=r.best_aic,
-        loss_rmse=_gui_batch_loss_rmse(time_numeric, od_for_fit, Float64.(fit_time_out), fit_for_loss, t_peak),
+        loss_rmse=_gui_batch_loss_rmse(
+            preprocessed_time,
+            preprocessed_od,
+            Float64.(r.times),
+            Float64.(r.fitted_curve),
+            stationary_phase_start,
+        ),
         loss_re=r.loss,
     )
 end
@@ -405,32 +425,30 @@ function _gui_batch_fit_one(
     stochastic_runs::Int=1,
     maxiters::Int=100000,
     abstol::Float64=1e-15,
+    smooth::Bool=false,
+    smooth_window::Int=3,
     compute_loglin::Bool=false,
     loglin_pt_avg::Int=7,
     loglin_pt_smoothing_derivative::Int=7,
     loglin_pt_min_size_of_win::Int=7,
     loglin_threshold_of_exp::Float64=0.9,
 )
-    if subtract_blank && blank_value > 0.0
-        corrected = (blank_method == "pointbypoint" && length(blank_timeseries) == length(od_raw)) ?
-            od_raw .- blank_timeseries : od_raw .- blank_value
-        od_subtracted_display = max.(corrected, 0.0)
-        anchor = od_subtracted_display[1]
-        if blank_method == "clip"
-            od_for_fit = max.(corrected, 1e-4)
-            shift = 0.0
-        else
-            shift = max(-minimum(corrected), 0.0) + 1e-4
-            od_for_fit = corrected .+ shift
-        end
-    else
-        od_subtracted_display = nothing
-        od_for_fit = max.(od_raw, 0.01)
-        anchor = od_raw[1]
-        shift = 0.0
+    if smooth && (smooth_window < 3 || iseven(smooth_window))
+        throw(ArgumentError("smooth_window must be an odd integer greater than or equal to 3"))
     end
 
-    t_peak = time_numeric[argmax(od_for_fit)]
+    prepared = _gui_prepare_curve(
+        od_raw;
+        blank_value,
+        subtract_blank,
+        blank_method,
+        blank_timeseries,
+        unblanked_floor=0.01,
+    )
+    od_for_fit = prepared.od_for_fit
+    od_subtracted_display = prepared.od_subtracted_display
+    shift = prepared.shift
+
     attempts = Tuple{String, Int}[]
     if !isempty(deterministic_optimizers) || !isempty(stochastic_optimizers)
         append!(attempts, [(opt, 1) for opt in deterministic_optimizers])
@@ -446,9 +464,9 @@ function _gui_batch_fit_one(
     for (opt, run_idx) in attempts
         try
             res = _gui_batch_run_attempt(
-                opt, time_numeric, od_for_fit, t_peak, anchor, shift,
+                opt, time_numeric, od_for_fit, shift,
                 subtract_blank, blank_value, label, model_name, model_names,
-                maxiters, abstol,
+                maxiters, abstol, smooth, smooth_window,
             )
             push!(outcomes, (optimizer=opt, run=run_idx, status="ok", loss=res.loss_rmse,
                 loss_rmse=res.loss_rmse, loss_re=res.loss_re, aic=res.aic, result=res))
@@ -475,7 +493,18 @@ function _gui_batch_fit_one(
         "blank_value" => blank_value,
         "blank_subtraction" => subtract_blank,
         "blank_method" => blank_method,
-        "stationary_phase_start" => t_peak,
+        "stationary_phase_start" => win.stationary_phase_start,
+        "maxiters" => maxiters,
+        "abstol" => abstol,
+        "preprocessing" => Dict(
+            "smooth" => smooth,
+            "smooth_method" => smooth ? "boxcar" : "none",
+            "smooth_window" => smooth_window,
+            "cut_stationary_phase" => true,
+            "stationary_percentile_thr" => 0.05,
+            "stationary_pt_smooth_derivative" => 10,
+            "stationary_win_size" => 5,
+        ),
         "aic" => win.aic,
         "loss" => win.loss_rmse,
         "loss_rmse" => win.loss_rmse,
@@ -487,6 +516,10 @@ function _gui_batch_fit_one(
             "loss_re" => o.loss_re, "aic" => o.aic) for o in outcomes],
     )
     od_subtracted_display !== nothing && (result["experimental_od_subtracted"] = od_subtracted_display)
+    if smooth
+        result["smoothed_time"] = win.preprocessed_time
+        result["smoothed_od"] = win.preprocessed_od
+    end
     if compute_loglin
         merge!(result, _gui_batch_loglin_fields(
             time_numeric, od_for_fit, label, experiment;
@@ -510,10 +543,14 @@ The returned `model` field is `"multi"` when more than one parametric model
 is compared (and `model_names` holds the list); when a single model is
 fitted, `model` is its name and `model_names == [model]`.
 
-Each result carries two loss fields: `loss_re` is the optimizer objective
-(relative error on the smoothed/blank-shifted curve) and `loss_rmse` is
-recomputed on the displayed blank-corrected curve. The "best" optimizer
-attempt is chosen by minimum `loss_rmse`.
+Each result carries two loss fields: `loss_re` is the relative-error objective
+minimized by Kinbiont, whereas `loss_rmse` is recomputed against the same
+preprocessed observations through the Kinbiont stationary-phase cutoff.
+GUIbiont selects the optimizer attempt with the lowest `loss_rmse`.
+
+Set `smooth=true` to apply the same centered moving average to every optimizer
+attempt before stationary-phase detection. `smooth_window` is the odd window
+width and defaults to 3 (one point on either side of the current point).
 """
 function kinbiont_batch_fit(
     data::GrowthData;
@@ -528,6 +565,8 @@ function kinbiont_batch_fit(
     maxiters::Int=100000,
     abstol::Float64=1e-15,
     skip_flat_threshold::Float64=0.05,
+    smooth::Bool=false,
+    smooth_window::Int=3,
     compute_loglin::Bool=false,
     loglin_pt_avg::Int=7,
     loglin_pt_smoothing_derivative::Int=7,
@@ -538,6 +577,10 @@ function kinbiont_batch_fit(
     blank_value::Real=0.0,
     blank_timeseries::Vector{Float64}=Float64[],
 )
+    if smooth && (smooth_window < 3 || iseven(smooth_window))
+        throw(ArgumentError("smooth_window must be an odd integer greater than or equal to 3"))
+    end
+
     selected = isempty(labels) ? data.labels : labels
     results = Dict{String, Any}[]
     skipped = Dict{String, Any}[]
@@ -583,6 +626,8 @@ function kinbiont_batch_fit(
                 stochastic_runs=stochastic_runs,
                 maxiters=maxiters,
                 abstol=abstol,
+                smooth=smooth,
+                smooth_window=smooth_window,
                 compute_loglin=compute_loglin,
                 loglin_pt_avg=loglin_pt_avg,
                 loglin_pt_smoothing_derivative=loglin_pt_smoothing_derivative,
@@ -600,6 +645,8 @@ function kinbiont_batch_fit(
         experiment=experiment,
         model=model_out,
         model_names=model_names_out,
+        smooth=smooth,
+        smooth_window=smooth_window,
         results=results,
         skipped=skipped,
         errors=errors,
@@ -680,20 +727,16 @@ function _gui_batch_fit_loglin_one(
     start_exp_win_thr::Float64=0.05,
     thr_lowess::Float64=0.05,
 )
-    od_subtracted_display = nothing
-    if subtract_blank && blank_value > 0.0
-        corrected = (blank_method == "pointbypoint" && length(blank_timeseries) == length(od_raw)) ?
-            od_raw .- blank_timeseries : od_raw .- blank_value
-        od_subtracted_display = max.(corrected, 0.0)
-        if blank_method == "clip"
-            od_for_fit = max.(corrected, 1e-4)
-        else
-            shift = max(-minimum(corrected), 0.0) + 1e-4
-            od_for_fit = corrected .+ shift
-        end
-    else
-        od_for_fit = max.(od_raw, 1e-4)
-    end
+    prepared = _gui_prepare_curve(
+        od_raw;
+        blank_value,
+        subtract_blank,
+        blank_method,
+        blank_timeseries,
+        unblanked_floor=1e-4,
+    )
+    od_for_fit = prepared.od_for_fit
+    od_subtracted_display = prepared.od_subtracted_display
 
     raw = fitting_one_well_Log_Lin(
         Matrix(transpose(hcat(time_numeric, od_for_fit))),

--- a/src/api/batch.jl
+++ b/src/api/batch.jl
@@ -595,7 +595,7 @@ function kinbiont_batch_fit(
     stochastic_runs::Int=1,
     maxiters::Int=100000,
     abstol::Float64=1e-15,
-    skip_flat_threshold::Float64=0.05,
+    skip_flat_threshold::Float64=0.02,
     smooth::Bool=false,
     smooth_window::Int=3,
     compute_loglin::Bool=false,
@@ -919,7 +919,7 @@ function kinbiont_batch_loglin(
     threshold_of_exp::Float64=0.9,
     start_exp_win_thr::Float64=0.05,
     thr_lowess::Float64=0.05,
-    skip_flat_threshold::Float64=0.05,
+    skip_flat_threshold::Float64=0.02,
 )
     selected = isempty(labels) ? data.labels : labels
     results = Dict{String, Any}[]

--- a/src/api/clustering_helpers.jl
+++ b/src/api/clustering_helpers.jl
@@ -9,67 +9,11 @@ using CSV, DataFrames
 using Clustering: silhouettes, clustering_quality
 
 """
-    apply_blank_timeseries(curves, blank_timeseries; method=:pointbypoint) -> Matrix{Float64}
-
-Subtract a per-timepoint blank trace from every curve in `curves` (rows = curves,
-columns = timepoints) and return a new matrix.
-
-`method` selects the correction style:
-- `:pointbypoint` — subtract `blank_timeseries[t]` from each timepoint. Non-finite
-  blank values are treated as zero (no correction at that timepoint).
-- `:shift` — subtract the mean of the (finite) blank trace, then shift each curve
-  so its minimum is ≥ 0.
-- `:clip` — subtract the mean of the (finite) blank trace, then clamp negatives
-  to 0.
-
-`blank_timeseries` must be at least as long as the number of timepoints.
-"""
-function apply_blank_timeseries(
-    curves::Matrix{Float64},
-    blank_timeseries::Vector{Float64};
-    method::Symbol = :pointbypoint,
-)::Matrix{Float64}
-    n_tp = size(curves, 2)
-    length(blank_timeseries) >= n_tp ||
-        throw(ArgumentError("blank_timeseries length $(length(blank_timeseries)) < n_timepoints $n_tp"))
-    ts = blank_timeseries[1:n_tp]
-    out = copy(curves)
-
-    if method == :pointbypoint
-        # Replace non-finite blank entries with 0 so they leave the curve untouched
-        # at that timepoint (consistent with :shift / :clip which filter to finite).
-        ts_safe = [isfinite(v) ? v : 0.0 for v in ts]
-        for i in axes(out, 1)
-            out[i, :] = out[i, :] .- ts_safe
-        end
-    elseif method == :shift
-        finite = filter(isfinite, ts)
-        isempty(finite) && return out
-        blank_mean = mean(finite)
-        for i in axes(out, 1)
-            corrected = out[i, :] .- blank_mean
-            finite_corrected = filter(isfinite, corrected)
-            shift = isempty(finite_corrected) ? 0.0 : min(0.0, minimum(finite_corrected))
-            out[i, :] = corrected .- shift
-        end
-    elseif method == :clip
-        finite = filter(isfinite, ts)
-        isempty(finite) && return out
-        blank_mean = mean(finite)
-        for i in axes(out, 1)
-            out[i, :] = max.(out[i, :] .- blank_mean, 0.0)
-        end
-    else
-        throw(ArgumentError("Unknown blank correction method: $method"))
-    end
-    return out
-end
-
-"""
     detect_blank_indices(curves, times; flat_p_thr=0.05, flat_range_thr=0.005, od_percentile=0.10) -> Vector{Int}
 
 Return the row indices in `curves` that look like blank wells: curves that are
-both *flat* (no significant linear trend at p ≥ `flat_p_thr` **or** OD range
+both *flat* (no significant linear trend under a two-sided Normal approximation
+at p ≥ `flat_p_thr` **or** OD range
 < `flat_range_thr`) and have a mean OD in the lowest `od_percentile` quantile of
 all finite curve means.
 """
@@ -80,10 +24,8 @@ function detect_blank_indices(
     flat_range_thr::Float64 = 0.005,
     od_percentile::Float64 = 0.10,
 )::Vector{Int}
-    flat_flags = _flat_curve_mask(curves, times;
-        p_threshold=flat_p_thr,
-        range_threshold=flat_range_thr,
-    )
+    flat_flags = _normal_approx_flat_mask(curves, times;
+        p_threshold=flat_p_thr, range_threshold=flat_range_thr)
 
     mean_ods = Float64[]
     for i in axes(curves, 1)
@@ -145,8 +87,9 @@ end
     interpolate_curves_to_grid(curves_all, times_all, grid) -> Matrix{Float64}
 
 Linearly interpolate each curve in `curves_all` (paired with its own time vector
-in `times_all`) onto the common `grid`. Values outside a curve's own time range
-are clamped to the nearest endpoint. Empty curves produce a row of `NaN`.
+in `times_all`) onto the common `grid`. Non-finite time/value pairs are ignored;
+values outside a curve's finite time range are clamped to the nearest endpoint.
+Curves without a finite measurement produce a row of `NaN`.
 """
 function interpolate_curves_to_grid(
     curves_all::Vector{Vector{Float64}},
@@ -159,13 +102,18 @@ function interpolate_curves_to_grid(
     for (i, (y, t)) in enumerate(zip(curves_all, times_all))
         length(y) == length(t) ||
             throw(ArgumentError("curve $i: values and times must have the same length"))
-        if isempty(y)
+        finite = isfinite.(t) .& isfinite.(y)
+        if !any(finite)
             out[i, :] .= NaN
             continue
         end
-        ord = sortperm(t)
-        t_s = t[ord]
-        y_s = y[ord]
+        t_f, y_f = t[finite], y[finite]
+        ord = sortperm(t_f)
+        t_s, y_s = t_f[ord], y_f[ord]
+        if length(t_s) == 1
+            out[i, :] .= y_s[1]
+            continue
+        end
         for (j, tg) in enumerate(grid)
             if tg <= t_s[1]
                 out[i, j] = y_s[1]
@@ -179,6 +127,170 @@ function interpolate_curves_to_grid(
         end
     end
     return out
+end
+
+function _normal_approx_flat_mask(
+    curves::Matrix{Float64},
+    times::Vector{Float64};
+    p_threshold::Float64=0.05,
+    range_threshold::Union{Nothing,Float64}=nothing,
+)::BitVector
+    length(times) == size(curves, 2) || throw(ArgumentError(
+        "times length $(length(times)) != n_timepoints $(size(curves, 2))"
+    ))
+    mask = falses(size(curves, 1))
+    length(times) < 3 && return mask
+
+    for i in axes(curves, 1)
+        finite = isfinite.(curves[i, :]) .& isfinite.(times)
+        sum(finite) < 3 && continue
+        y, t = curves[i, finite], times[finite]
+        if range_threshold !== nothing && maximum(y) - minimum(y) < range_threshold
+            mask[i] = true
+            continue
+        end
+        tc = t .- mean(t)
+        ss_t = sum(tc .^ 2)
+        if ss_t <= 1e-12
+            mask[i] = true
+            continue
+        end
+        slope = sum(tc .* y) / ss_t
+        residuals = y .- (mean(y) .+ slope .* tc)
+        se = sqrt(max(sum(residuals .^ 2) / (length(y) - 2), 0.0) / ss_t)
+        if se <= 0 || !isfinite(se)
+            mask[i] = abs(slope) < 1e-12
+            continue
+        end
+        p_value = 2 * (1 - cdf(Normal(), abs(slope / se)))
+        mask[i] = p_value >= p_threshold
+    end
+    return mask
+end
+
+"""
+    apply_grouped_blank_subtraction(curves, times, groups,
+                                    blank_curves, blank_times, blank_groups;
+                                    method=:pointbypoint)
+
+Correct every sample curve using only blank curves from the same group. Blank
+curves are linearly interpolated onto each sample's time grid before their
+pointwise mean is computed, so measurements are paired by time rather than by
+column index. Samples whose group has no blank curve are returned unchanged.
+
+Returns `(corrected_curves, corrected_mask)`, where `corrected_mask[i]` records
+whether sample `i` had a same-group blank available.
+"""
+function apply_grouped_blank_subtraction(
+    curves::Vector{Vector{Float64}},
+    times::Vector{Vector{Float64}},
+    groups::Vector{String},
+    blank_curves::Vector{Vector{Float64}},
+    blank_times::Vector{Vector{Float64}},
+    blank_groups::Vector{String};
+    method::Symbol = :pointbypoint,
+)::Tuple{Vector{Vector{Float64}},BitVector}
+    length(curves) == length(times) == length(groups) || throw(ArgumentError(
+        "curves, times, and groups must have the same length"
+    ))
+    length(blank_curves) == length(blank_times) == length(blank_groups) ||
+        throw(ArgumentError("blank_curves, blank_times, and blank_groups must have the same length"))
+
+    blanks_by_group = Dict{String,Vector{Int}}()
+    for (i, group) in enumerate(blank_groups)
+        push!(get!(blanks_by_group, group, Int[]), i)
+    end
+
+    corrected = deepcopy(curves)
+    corrected_mask = falses(length(curves))
+    for i in eachindex(curves)
+        length(curves[i]) == length(times[i]) || throw(ArgumentError(
+            "sample $i: values and times must have the same length"
+        ))
+        blank_idx = get(blanks_by_group, groups[i], Int[])
+        isempty(blank_idx) && continue
+
+        aligned_blanks = interpolate_curves_to_grid(
+            blank_curves[blank_idx], blank_times[blank_idx], times[i]
+        )
+        blank_trace = Vector{Float64}(undef, length(times[i]))
+        for j in eachindex(blank_trace)
+            finite_values = filter(isfinite, aligned_blanks[:, j])
+            blank_trace[j] = isempty(finite_values) ? 0.0 : mean(finite_values)
+        end
+        corrected_row = apply_blank_timeseries(
+            reshape(curves[i], 1, :), blank_trace; method=method
+        )
+        corrected[i] = vec(corrected_row)
+        corrected_mask[i] = true
+    end
+    return corrected, corrected_mask
+end
+
+"""
+    derive_blank_from_non_growing(curves, times, labels, groups,
+                                  detection_curves, detection_times; kwargs...)
+
+Use the selected non-growing criteria to derive blank wells. Matching rows are
+removed from the sample matrix and combined with any annotated blanks, then the
+remaining samples are corrected within their own group. `detection_curves` may
+be a smoothed version of `curves`; the unsmoothed rows are used for the blank
+trace itself.
+"""
+function derive_blank_from_non_growing(
+    curves::Matrix{Float64},
+    times::Vector{Float64},
+    labels::Vector{String},
+    groups::Vector{String},
+    detection_curves::Matrix{Float64},
+    detection_times::Vector{Float64};
+    annotated_blank_curves::Vector{Vector{Float64}}=Vector{Vector{Float64}}(),
+    annotated_blank_times::Vector{Vector{Float64}}=Vector{Vector{Float64}}(),
+    annotated_blank_groups::Vector{String}=String[],
+    annotated_blank_labels::Vector{String}=String[],
+    prescreen_constant::Bool=false,
+    trend_test::Bool=false,
+    prescreen_tol::Float64=1.5,
+    prescreen_q_low::Float64=0.05,
+    prescreen_q_high::Float64=0.95,
+    trend_p_threshold::Float64=0.05,
+    blank_method::Symbol=:pointbypoint,
+)
+    size(curves, 1) == length(labels) == length(groups) || throw(ArgumentError(
+        "curves, labels, and groups must contain the same number of samples"
+    ))
+    size(detection_curves, 1) == size(curves, 1) || throw(ArgumentError(
+        "detection_curves must contain one row per sample"
+    ))
+    derived_idx = detect_non_growing_indices(
+        detection_curves, detection_times;
+        prescreen_constant, trend_test, prescreen_tol,
+        prescreen_q_low, prescreen_q_high, trend_p_threshold,
+    )
+    keep = setdiff(1:size(curves, 1), derived_idx)
+
+    derived_curves = [Vector(curves[i, :]) for i in derived_idx]
+    all_blank_curves = vcat(annotated_blank_curves, derived_curves)
+    all_blank_times = vcat(annotated_blank_times, [copy(times) for _ in derived_idx])
+    all_blank_groups = vcat(annotated_blank_groups, groups[derived_idx])
+    all_blank_labels = vcat(annotated_blank_labels, labels[derived_idx])
+
+    remaining = [Vector(curves[i, :]) for i in keep]
+    corrected, corrected_mask = apply_grouped_blank_subtraction(
+        remaining, [copy(times) for _ in keep], groups[keep],
+        all_blank_curves, all_blank_times, all_blank_groups;
+        method=blank_method,
+    )
+    corrected_matrix = isempty(corrected) ? zeros(Float64, 0, size(curves, 2)) :
+                       reduce(vcat, permutedims.(corrected))
+    return (
+        curves=corrected_matrix,
+        labels=labels[keep],
+        groups=groups[keep],
+        blank_labels=all_blank_labels,
+        derived_indices=derived_idx,
+        corrected_mask=corrected_mask,
+    )
 end
 
 """
@@ -290,33 +402,41 @@ function _load_clustering_csv(path::String)
     any(isnan, times_raw) && (times_raw = Float64.(0:(nrow(raw_df) - 1)))
     labels = String.(col_names[(time_col_idx + 1):end])
     curves_all = [_to_f64_vector(raw_df[!, label]) for label in labels]
-    return [times_raw for _ in labels], curves_all, labels, Vector{Vector{Float64}}(), String[]
+    groups = fill("uploaded_matrix", length(labels))
+    return [times_raw for _ in labels], curves_all, labels, groups,
+           Vector{Vector{Float64}}(), Vector{Vector{Float64}}(), String[], String[]
 end
 
-function _annotation_blank_wells(path::String)
+function _annotation_well_sets(path::String)
+    excluded = Set{String}()
     blanks = Set{String}()
-    isfile(path) || return blanks
+    isfile(path) || return excluded, blanks
     ann = CSV.read(path, DataFrame; header=false, silencewarnings=true, stringtype=String)
     for i in 1:nrow(ann)
         ncol(ann) >= 2 || continue
         marker = string(ann[i, 2])
-        marker in ("b", "X", "x") && push!(blanks, string(ann[i, 1]))
+        well = string(ann[i, 1])
+        marker in ("b", "X", "x") && push!(excluded, well)
+        marker == "b" && push!(blanks, well)
     end
-    return blanks
+    return excluded, blanks
 end
 
 function _load_clustering_experiments(clean_data_path::String, experiments::Vector{String})
     times_all = Vector{Vector{Float64}}()
     curves_all = Vector{Vector{Float64}}()
     labels = String[]
+    groups = String[]
     blank_curves_all = Vector{Vector{Float64}}()
+    blank_times_all = Vector{Vector{Float64}}()
     blank_labels = String[]
+    blank_groups = String[]
     for exp_name in experiments
         data_file = joinpath(clean_data_path, exp_name, "data_channel_1.csv")
         annotation_file = joinpath(clean_data_path, exp_name, "annotation_clean.csv")
         isfile(data_file) || continue
         gd_raw = CSV.read(data_file, DataFrame; header=1, silencewarnings=true)
-        blank_wells = _annotation_blank_wells(annotation_file)
+        excluded_wells, blank_wells = _annotation_well_sets(annotation_file)
         time_col = names(gd_raw)[1]
         time_data = gd_raw[!, time_col]
         time_numeric = if eltype(time_data) <: AbstractString
@@ -331,17 +451,23 @@ function _load_clustering_experiments(clean_data_path::String, experiments::Vect
         end
         for well in names(gd_raw)[2:end]
             od = _to_f64_vector(gd_raw[!, well])
-            if well in blank_wells
-                push!(blank_curves_all, od)
-                push!(blank_labels, "$(exp_name)/$(well)")
+            if well in excluded_wells
+                if well in blank_wells
+                    push!(blank_curves_all, od)
+                    push!(blank_times_all, time_numeric)
+                    push!(blank_labels, "$(exp_name)/$(well)")
+                    push!(blank_groups, exp_name)
+                end
             else
                 push!(times_all, time_numeric)
                 push!(curves_all, od)
                 push!(labels, "$(exp_name)/$(well)")
+                push!(groups, exp_name)
             end
         end
     end
-    return times_all, curves_all, labels, blank_curves_all, blank_labels
+    return times_all, curves_all, labels, groups,
+           blank_curves_all, blank_times_all, blank_labels, blank_groups
 end
 
 # Strip a trailing NaN tail from a curve so it can be resampled by
@@ -365,7 +491,7 @@ Source (one of):
   sentinel skipped), remaining columns are wells.
 - `clean_data_path` + `experiments` — GUIbiont layout where each experiment is a
   subdirectory containing `data_channel_1.csv` and `annotation_clean.csv`
-  (annotation markers `"b"`, `"X"`, `"x"` flag blanks).
+  (`"b"` marks blanks; `"X"`/`"x"` wells are excluded without being used as blanks).
 
 Pipeline options:
 - `interpolate` — resample all curves onto a common quantile-trimmed grid.
@@ -390,8 +516,20 @@ function prepare_clustering_data(;
     blank_method::Symbol = :pointbypoint,
     blank_range_thr::Float64 = 0.005,
     blank_od_percentile::Float64 = 0.10,
+    derive_non_growing_blanks::Bool = false,
+    blank_prescreen_constant::Bool = false,
+    blank_trend_test::Bool = false,
+    blank_prescreen_tol::Float64 = 1.5,
+    blank_prescreen_q_low::Float64 = 0.05,
+    blank_prescreen_q_high::Float64 = 0.95,
+    blank_trend_p_threshold::Float64 = 0.05,
+    detection_smooth::Bool = false,
+    detection_smooth_method::Symbol = :lowess,
+    detection_lowess_frac::Float64 = 0.05,
+    detection_gaussian_h_mult::Float64 = 2.0,
 )::GrowthData
-    times_all, curves_all, labels, blank_curves_all, blank_labels = if !isempty(csv_path)
+    times_all, curves_all, labels, groups, blank_curves_all, blank_times_all,
+    blank_labels, blank_groups = if !isempty(csv_path)
         _load_clustering_csv(csv_path)
     else
         isempty(clean_data_path) && error("clean_data_path is required when csv_path is empty")
@@ -399,6 +537,17 @@ function prepare_clustering_data(;
         _load_clustering_experiments(clean_data_path, experiments)
     end
     isempty(curves_all) && error("No data loaded")
+
+    # Annotated blanks are paired within each experiment on the sample's real
+    # time grid. This must happen before any cross-experiment resampling.
+    annotated_blanks = !isempty(blank_curves_all)
+    if subtract_blank && annotated_blanks && !derive_non_growing_blanks
+        curves_all, _ = apply_grouped_blank_subtraction(
+            curves_all, times_all, groups,
+            blank_curves_all, blank_times_all, blank_groups;
+            method=blank_method,
+        )
+    end
 
     if interpolate
         times = common_time_grid(times_all; n_grid=max(10, interp_n),
@@ -409,17 +558,17 @@ function prepare_clustering_data(;
         clean_times = Vector{Vector{Float64}}()
         clean_curves = Vector{Vector{Float64}}()
         clean_labels = String[]
+        clean_groups = String[]
         for i in eachindex(curves_all)
             stripped = _strip_nan_tail_for_clustering(times_all[i], curves_all[i])
             stripped === nothing && continue
             ct, cy = stripped
             push!(clean_times, ct); push!(clean_curves, cy); push!(clean_labels, labels[i])
+            push!(clean_groups, groups[i])
         end
         isempty(clean_curves) && error("No valid curves after NaN removal")
         igd = IrregularGrowthData(clean_curves, clean_times, clean_labels; step=0.01)
-        times, curves, labels = igd.times, igd.curves, clean_labels
-        blank_curves_all = Vector{Vector{Float64}}()
-        blank_labels     = String[]
+        times, curves, labels, groups = igd.times, igd.curves, clean_labels, clean_groups
     else
         min_len = minimum(length.(curves_all))
         times = times_all[1][1:min_len]
@@ -429,23 +578,74 @@ function prepare_clustering_data(;
         end
     end
 
-    if isempty(blank_curves_all) && auto_detect_blanks
-        blank_idxs = detect_blank_indices(curves, times;
-            flat_range_thr=blank_range_thr, od_percentile=blank_od_percentile)
+    if derive_non_growing_blanks
+        (blank_prescreen_constant || blank_trend_test) || error(
+            "derive_non_growing_blanks requires blank_prescreen_constant or blank_trend_test"
+        )
+        detector_curves = fill_nonfinite_colmean(curves)
+        detector_times = times
+        if detection_smooth
+            detector_data = preprocess(
+                GrowthData(detector_curves, times, labels),
+                FitOptions(
+                    smooth=true,
+                    smooth_method=detection_smooth_method,
+                    lowess_frac=detection_lowess_frac,
+                    gaussian_h_mult=detection_gaussian_h_mult,
+                    cluster=false,
+                ),
+            )
+            detector_curves = detector_data.curves
+            detector_times = detector_data.times
+        end
+        derived = derive_blank_from_non_growing(
+            curves, times, labels, groups, detector_curves, detector_times;
+            annotated_blank_curves=blank_curves_all,
+            annotated_blank_times=blank_times_all,
+            annotated_blank_groups=blank_groups,
+            annotated_blank_labels=blank_labels,
+            prescreen_constant=blank_prescreen_constant,
+            trend_test=blank_trend_test,
+            prescreen_tol=blank_prescreen_tol,
+            prescreen_q_low=blank_prescreen_q_low,
+            prescreen_q_high=blank_prescreen_q_high,
+            trend_p_threshold=blank_trend_p_threshold,
+            blank_method,
+        )
+        isempty(derived.derived_indices) && error("No non-growing curves were detected for blank derivation")
+        isempty(derived.labels) && error("No sample curves remain after blank derivation")
+        curves, labels, groups = derived.curves, derived.labels, derived.groups
+    end
+
+    if !derive_non_growing_blanks && !annotated_blanks && auto_detect_blanks
+        blank_idxs = Int[]
+        for group in unique(groups)
+            group_rows = findall(==(group), groups)
+            local_idxs = detect_blank_indices(curves[group_rows, :], times;
+                flat_range_thr=blank_range_thr, od_percentile=blank_od_percentile)
+            append!(blank_idxs, group_rows[local_idxs])
+        end
         if !isempty(blank_idxs)
             blank_curves_all = [Vector(curves[i, :]) for i in blank_idxs]
             blank_labels     = labels[blank_idxs]
+            blank_times_all = [copy(times) for _ in blank_idxs]
+            blank_groups = groups[blank_idxs]
             keep = setdiff(1:size(curves, 1), blank_idxs)
-            curves, labels = curves[keep, :], labels[keep]
+            isempty(keep) && error("No sample curves remain after blank removal")
+            curves, labels, groups = curves[keep, :], labels[keep], groups[keep]
         end
     end
 
-    # Blank correction is performed separately within each loaded experiment,
-    # matching the GUIbiont clustering route: each experiment's wells are
-    # corrected using only that experiment's own blanks.
-    if subtract_blank && !isempty(blank_curves_all)
-        curves = _subtract_blanks_per_experiment(curves, labels,
-            blank_curves_all, blank_labels, blank_method, !isempty(csv_path))
+    # Auto-detected blanks already share the prepared grid, but remain grouped
+    # so one experiment can never supply the correction for another.
+    if !derive_non_growing_blanks && subtract_blank && !annotated_blanks && !isempty(blank_curves_all)
+        curve_vectors = [Vector(curves[i, :]) for i in axes(curves, 1)]
+        corrected, _ = apply_grouped_blank_subtraction(
+            curve_vectors, [copy(times) for _ in curve_vectors], groups,
+            blank_curves_all, blank_times_all, blank_groups;
+            method=blank_method,
+        )
+        curves = reduce(vcat, permutedims.(corrected))
     end
 
     return GrowthData(fill_nonfinite_colmean(curves), times, labels)
@@ -497,9 +697,10 @@ function _subtract_blanks_per_experiment(
 end
 
 export detect_blank_indices
-export apply_blank_timeseries
 export fill_nonfinite_colmean
 export common_time_grid
 export interpolate_curves_to_grid
+export apply_grouped_blank_subtraction
+export derive_blank_from_non_growing
 export cluster_quality_indices
 export prepare_clustering_data

--- a/src/api/clustering_helpers.jl
+++ b/src/api/clustering_helpers.jl
@@ -177,6 +177,8 @@ Correct every sample curve using only blank curves from the same group. Blank
 curves are linearly interpolated onto each sample's time grid before their
 pointwise mean is computed, so measurements are paired by time rather than by
 column index. Samples whose group has no blank curve are returned unchanged.
+Corrected curves are kept at or above `floor` (default `1e-4`), matching the
+blank-subtraction policy used by fitting.
 
 Returns `(corrected_curves, corrected_mask)`, where `corrected_mask[i]` records
 whether sample `i` had a same-group blank available.
@@ -189,6 +191,7 @@ function apply_grouped_blank_subtraction(
     blank_times::Vector{Vector{Float64}},
     blank_groups::Vector{String};
     method::Symbol = :pointbypoint,
+    floor::Union{Nothing,Float64} = 1e-4,
 )::Tuple{Vector{Vector{Float64}},BitVector}
     length(curves) == length(times) == length(groups) || throw(ArgumentError(
         "curves, times, and groups must have the same length"
@@ -219,7 +222,7 @@ function apply_grouped_blank_subtraction(
             blank_trace[j] = isempty(finite_values) ? 0.0 : mean(finite_values)
         end
         corrected_row = apply_blank_timeseries(
-            reshape(curves[i], 1, :), blank_trace; method=method
+            reshape(curves[i], 1, :), blank_trace; method=method, floor=floor
         )
         corrected[i] = vec(corrected_row)
         corrected_mask[i] = true
@@ -255,6 +258,7 @@ function derive_blank_from_non_growing(
     prescreen_q_high::Float64=0.95,
     trend_p_threshold::Float64=0.05,
     blank_method::Symbol=:pointbypoint,
+    blank_floor::Union{Nothing,Float64}=1e-4,
 )
     size(curves, 1) == length(labels) == length(groups) || throw(ArgumentError(
         "curves, labels, and groups must contain the same number of samples"
@@ -280,6 +284,7 @@ function derive_blank_from_non_growing(
         remaining, [copy(times) for _ in keep], groups[keep],
         all_blank_curves, all_blank_times, all_blank_groups;
         method=blank_method,
+        floor=blank_floor,
     )
     corrected_matrix = isempty(corrected) ? zeros(Float64, 0, size(curves, 2)) :
                        reduce(vcat, permutedims.(corrected))
@@ -514,6 +519,7 @@ function prepare_clustering_data(;
     auto_detect_blanks::Bool = true,
     subtract_blank::Bool = false,
     blank_method::Symbol = :pointbypoint,
+    blank_floor::Union{Nothing,Float64} = 1e-4,
     blank_range_thr::Float64 = 0.005,
     blank_od_percentile::Float64 = 0.10,
     derive_non_growing_blanks::Bool = false,
@@ -546,6 +552,7 @@ function prepare_clustering_data(;
             curves_all, times_all, groups,
             blank_curves_all, blank_times_all, blank_groups;
             method=blank_method,
+            floor=blank_floor,
         )
     end
 
@@ -611,6 +618,7 @@ function prepare_clustering_data(;
             prescreen_q_high=blank_prescreen_q_high,
             trend_p_threshold=blank_trend_p_threshold,
             blank_method,
+            blank_floor,
         )
         isempty(derived.derived_indices) && error("No non-growing curves were detected for blank derivation")
         isempty(derived.labels) && error("No sample curves remain after blank derivation")
@@ -644,6 +652,7 @@ function prepare_clustering_data(;
             curve_vectors, [copy(times) for _ in curve_vectors], groups,
             blank_curves_all, blank_times_all, blank_groups;
             method=blank_method,
+            floor=blank_floor,
         )
         curves = reduce(vcat, permutedims.(corrected))
     end

--- a/src/api/preprocessing.jl
+++ b/src/api/preprocessing.jl
@@ -8,12 +8,13 @@
 # pre_processing_functions.jl, and uses:
 #   - StatsBase.zscore   for z-score normalisation (replaces custom zscore_vector)
 #   - Clustering.kmeans  for k-means clustering (replaces custom implementation)
-#   - linear slope t-test (Statistics stdlib) for flat-curve trend detection
+#   - OLS slope significance test with a two-sided Normal approximation for
+#     flat-curve trend detection
 # =============================================================================
 
 using Clustering: kmeans, kmedoids, hclust, cutree, dbscan, assignments
 using StatsBase: zscore
-using Distributions: Normal, TDist, cdf
+using Distributions: Normal, cdf
 using Random: MersenneTwister
 
 # ---------------------------------------------------------------------------
@@ -886,15 +887,17 @@ function _flat_curve_mask(
         end
 
         t_stat = slope / se_slope
-        # Two-tailed p-value from the t-distribution with nf-2 degrees of freedom
-        p_value = 2 * (1 - cdf(TDist(nf - 2), abs(t_stat)))
+        # Two-tailed p-value using the normal approximation. Keep this aligned
+        # with the clustering blank-candidate trend test.
+        p_value = 2 * (1 - cdf(Normal(), abs(t_stat)))
         mask[i] = p_value >= p_threshold
     end
     return mask
 end
 
 # Assign a dedicated cluster id to curves with no significant linear trend.
-# Uses a two-tailed t-test on the OLS slope (p ≥ 0.05 → flat).
+# Uses a two-tailed Normal approximation for the OLS slope statistic
+# (p ≥ 0.05 → flat).
 # `flat_id` is passed in by the caller; it must already be within 1..n_clusters.
 function _apply_trend_labels(
     curves::Matrix{Float64},

--- a/src/api/preprocessing.jl
+++ b/src/api/preprocessing.jl
@@ -172,7 +172,7 @@ function _shift_rows_to_floor(curves::Matrix{Float64}, floor::Float64)::Matrix{F
     for i in axes(shifted, 1)
         finite_values = filter(isfinite, shifted[i, :])
         isempty(finite_values) && continue
-        delta = max(-minimum(finite_values), 0.0) + floor
+        delta = max(floor - minimum(finite_values), 0.0)
         shifted[i, :] .+= delta
     end
     return shifted

--- a/src/api/preprocessing.jl
+++ b/src/api/preprocessing.jl
@@ -13,7 +13,7 @@
 
 using Clustering: kmeans, kmedoids, hclust, cutree, dbscan, assignments
 using StatsBase: zscore
-using Distributions: TDist, cdf
+using Distributions: Normal, TDist, cdf
 using Random: MersenneTwister
 
 # ---------------------------------------------------------------------------
@@ -47,9 +47,9 @@ function preprocess(data::GrowthData, opts::FitOptions)::GrowthData
     times  = data.times
     labels = data.labels
 
-    # Resolve blank value before replicate averaging: averaging removes "b"-labelled
-    # wells, so _blank_from_labels would find nothing if called afterwards.
-    blank_val = _resolve_blank_value(curves, labels, opts)
+    # Resolve the scalar or point-by-point blank before replicate averaging,
+    # because averaging removes "b"-labelled wells.
+    blank = _resolve_blank_value(curves, labels, opts)
 
     curves, labels = _apply_replicate_averaging(curves, labels, opts)
 
@@ -60,7 +60,7 @@ function preprocess(data::GrowthData, opts::FitOptions)::GrowthData
     # non-growing wells (which is precisely what clustering is meant to find).
     clusters, centroids, wcss = opts.cluster ? _cluster(curves, times, opts) : (nothing, nothing, nothing)
 
-    curves = _apply_blank_subtraction(curves, blank_val, opts)
+    curves = _apply_blank_subtraction(curves, blank, opts)
     curves = _apply_negative_correction(curves, times, opts)
     curves, times = _apply_smoothing(curves, times, opts)   # Gaussian may change times
 
@@ -131,10 +131,58 @@ end
 # ---------------------------------------------------------------------------
 
 """
-    _resolve_blank_value(curves, labels, opts) -> Float64
+    apply_blank_timeseries(curves, blank_timeseries; method=:pointbypoint, floor=nothing)
 
-Determine the blank OD value to subtract. Must be called **before** replicate
-averaging, because averaging drops `"b"`-labelled wells from the matrix.
+Apply one blank trace to every curve. `:pointbypoint` subtracts the trace,
+`:shift` subtracts its finite mean and translates each row uniformly, and
+`:clip` subtracts its finite mean and floors the result. Passing a numeric
+`floor` also makes `:pointbypoint` translate each row above that floor; the
+default `nothing` preserves the legacy subtraction-only behaviour.
+"""
+function apply_blank_timeseries(
+    curves::Matrix{Float64},
+    blank_timeseries::Vector{Float64};
+    method::Symbol=:pointbypoint,
+    floor::Union{Nothing, Float64}=nothing,
+)::Matrix{Float64}
+    n_tp = size(curves, 2)
+    length(blank_timeseries) >= n_tp || throw(ArgumentError(
+        "blank_timeseries length $(length(blank_timeseries)) < n_timepoints $n_tp"
+    ))
+    ts = blank_timeseries[1:n_tp]
+
+    if method in (:pointbypoint, :pointwise, :time_avg)
+        ts_safe = [isfinite(v) ? v : 0.0 for v in ts]
+        corrected = curves .- reshape(ts_safe, 1, :)
+        return floor === nothing ? corrected : _shift_rows_to_floor(corrected, floor)
+    elseif method == :shift
+        finite = filter(isfinite, ts)
+        isempty(finite) && return copy(curves)
+        return _shift_rows_to_floor(curves .- mean(finite), something(floor, 0.0))
+    elseif method == :clip
+        finite = filter(isfinite, ts)
+        isempty(finite) && return copy(curves)
+        return max.(curves .- mean(finite), something(floor, 0.0))
+    end
+    throw(ArgumentError("Unknown blank correction method: $method"))
+end
+
+function _shift_rows_to_floor(curves::Matrix{Float64}, floor::Float64)::Matrix{Float64}
+    shifted = copy(curves)
+    for i in axes(shifted, 1)
+        finite_values = filter(isfinite, shifted[i, :])
+        isempty(finite_values) && continue
+        delta = max(-minimum(finite_values), 0.0) + floor
+        shifted[i, :] .+= delta
+    end
+    return shifted
+end
+
+"""
+    _resolve_blank_value(curves, labels, opts) -> Union{Float64,Vector{Float64}}
+
+Determine the scalar or point-by-point blank to subtract. Must be called
+**before** replicate averaging, because averaging drops `"b"`-labelled wells.
 
 Returns 0.0 when `opts.blank_subtraction` is false.
 """
@@ -142,23 +190,42 @@ function _resolve_blank_value(
     curves::Matrix{Float64},
     labels::Vector{String},
     opts::FitOptions,
-)::Float64
+)::Union{Float64, Vector{Float64}}
     opts.blank_subtraction || return 0.0
 
-    if opts.blank_from_labels
-        return _blank_from_labels(curves, labels)
-    else
-        return opts.blank_value
+    method = opts.blank_method
+    if method in (:pointbypoint, :pointwise, :time_avg)
+        if opts.blank_from_labels
+            return _blank_timeseries_from_labels(curves, labels)
+        end
+        opts.blank_timeseries === nothing && throw(ArgumentError(
+            "blank_method=:pointbypoint requires blank_timeseries or blank_from_labels=true"
+        ))
+        length(opts.blank_timeseries) == size(curves, 2) || throw(ArgumentError(
+            "blank_timeseries length $(length(opts.blank_timeseries)) does not match " *
+            "the number of time points $(size(curves, 2))"
+        ))
+        return [isfinite(v) ? v : 0.0 for v in opts.blank_timeseries]
+    elseif method in (:global, :average, :avg_blank, :avg_subtraction, :shift, :clip)
+        return opts.blank_from_labels ? _blank_from_labels(curves, labels) : opts.blank_value
     end
+    throw(ArgumentError("Unknown blank_method: $(opts.blank_method)"))
 end
 
 function _apply_blank_subtraction(
     curves::Matrix{Float64},
-    blank_val::Float64,
+    blank::Union{Float64, Vector{Float64}},
     opts::FitOptions,
 )::Matrix{Float64}
     opts.blank_subtraction || return curves
-    return curves .- blank_val
+    method = opts.blank_method
+    if method in (:pointbypoint, :pointwise, :time_avg)
+        return apply_blank_timeseries(curves, blank; method=:pointbypoint, floor=opts.blank_floor)
+    elseif method in (:shift, :clip)
+        blank_trace = fill(blank, size(curves, 2))
+        return apply_blank_timeseries(curves, blank_trace; method, floor=opts.blank_floor)
+    end
+    return curves .- blank
 end
 
 """
@@ -174,6 +241,36 @@ function _blank_from_labels(curves::Matrix{Float64}, labels::Vector{String})::Fl
         return 0.0
     end
     return mean(curves[blank_idx, :])
+end
+
+"""
+    _blank_timeseries_from_labels(curves, labels) -> Vector{Float64}
+
+Compute the per-timepoint mean across wells labelled `"b"`. Non-finite values
+are ignored; a time point with no finite blank measurement falls back to the
+mean of the other timepoint means, or 0.0 when no finite blank data exist.
+"""
+function _blank_timeseries_from_labels(
+    curves::Matrix{Float64},
+    labels::Vector{String},
+)::Vector{Float64}
+    blank_idx = findall(==("b"), labels)
+    if isempty(blank_idx)
+        @warn "blank_from_labels=true but no wells labelled \"b\" found; blank timeseries set to 0.0"
+        return zeros(Float64, size(curves, 2))
+    end
+
+    blank = Vector{Float64}(undef, size(curves, 2))
+    for j in axes(curves, 2)
+        values = filter(isfinite, curves[blank_idx, j])
+        blank[j] = isempty(values) ? NaN : mean(values)
+    end
+    finite_means = filter(isfinite, blank)
+    fallback = isempty(finite_means) ? 0.0 : mean(finite_means)
+    for j in eachindex(blank)
+        isfinite(blank[j]) || (blank[j] = fallback)
+    end
+    return blank
 end
 
 # ---------------------------------------------------------------------------
@@ -287,14 +384,16 @@ _smoothing_symbol_to_string(s::Symbol) = Dict(
 
 Apply a centered boxcar (symmetric moving-average) filter to every curve.
 Unlike `:rolling_avg`, the time grid is unchanged and no points are dropped.
-Window width is `opts.boxcar_window` (must be ≥ 1).
+Window width is `opts.boxcar_window` (an odd integer of at least 3).
 """
 function _apply_boxcar_smoothing(
     curves::Matrix{Float64},
     times::Vector{Float64},
     opts::FitOptions,
 )::Tuple{Matrix{Float64}, Vector{Float64}}
-    w = max(1, opts.boxcar_window)
+    w = opts.boxcar_window
+    w >= 3 || throw(ArgumentError("boxcar_window must be greater than or equal to 3"))
+    isodd(w) || throw(ArgumentError("boxcar_window must be odd so the average is centered"))
     half = w ÷ 2
     n_curves, n_tp = size(curves)
     smoothed = Matrix{Float64}(undef, n_curves, n_tp)
@@ -330,10 +429,10 @@ function _kmeans_best(X::AbstractMatrix{Float64}, k::Int, opts::FitOptions)
 end
 
 """
-    _cluster(curves, times, opts) -> (labels, centroids, wcss)
+    _cluster(curves, times, opts) -> (labels, centroids, cost)
 
 Cluster growth curves and return per-curve labels, per-cluster shape centroids,
-and the within-cluster sum of squares (WCSS / total SSE from k-means).
+and the method-specific clustering cost stored in the historical `wcss` field.
 
 Without exponential prototype relabeling, labels lie in `1..opts.n_clusters`.
 When `cluster_exp_prototype=true`, an additional label may be allocated (up to
@@ -343,14 +442,13 @@ each row is the mean of the z-scored curves assigned to that cluster. This captu
 the *shape* of each cluster independently of absolute OD magnitude. To recover
 original-space prototypes, compute the mean of `data.curves[data.clusters .== k, :]`
 for each `k`.
-`wcss` is the total SSE from the k-means step (0.0 when all curves were classified
-as constant).
+The cost is WCSS for k-means and hierarchical clustering, total distance to assigned
+medoids for k-medoids, and `0.0` for DBSCAN. Sentinel curves separated by a non-growing
+criterion are excluded from that cost.
 
-Modes (evaluated in priority order):
-1. `cluster_prescreen_constant=true`: quantile-ratio pre-screening identifies
-   non-growing wells before k-means, which then runs on dynamic curves only.
-2. `cluster_trend_test=true`: OLS slope t-test post-hoc re-labels flat curves.
-3. Neither: plain k-means on all curves.
+When the quantile pre-screen and slope trend test are enabled together, their union
+forms one non-growing group. For methods with a predefined `k`, clustering runs on
+the remaining dynamic curves; DBSCAN applies the same reassignment post-hoc.
 
 When `cluster_exp_prototype=true`, an additional exponential shape cluster is
 added after k-means: each curve is tested against pre-built z-scored exponential
@@ -375,21 +473,25 @@ function _cluster(
     zscored_all = _zscore_rows(curves)
     method      = opts.cluster_method
 
-    # Pre-screening: separate constant curves before running any clustering
-    # algorithm. Applies to all methods except :dbscan (no k parameter).
-    if opts.cluster_prescreen_constant && method != :dbscan
-        labels, wcss = _cluster_with_prescreen_method(curves, zscored_all, opts)
-    elseif opts.cluster_trend_test && method != :dbscan
-        labels, wcss = _cluster_with_trend_method(curves, times, zscored_all, opts)
+    # When both detectors are enabled, their union forms one non-growing class.
+    # DBSCAN applies the same union post-hoc because it has no k.
+    if (opts.cluster_prescreen_constant || opts.cluster_trend_test) && method != :dbscan
+        non_growing = _non_growing_mask(curves, times, opts)
+        labels, wcss = _cluster_with_non_growing_method(
+            zscored_all, non_growing, opts
+        )
     else
         labels, wcss = _cluster_dispatch(zscored_all, opts)
 
-        # DBSCAN has no k parameter, so trend-test flat reassignment has to be
-        # post-hoc and uses a fresh label above the DBSCAN cluster ids.
-        if opts.cluster_trend_test && !opts.cluster_prescreen_constant
-            flat_id = maximum(labels) + 1
-            labels  = _apply_trend_labels(curves, times, labels, flat_id,
-                                           opts.cluster_trend_p_thr)
+        # DBSCAN has no k parameter, so the selected non-growing criteria are
+        # applied post-hoc using one fresh label above its cluster ids.
+        if method == :dbscan &&
+           (opts.cluster_prescreen_constant || opts.cluster_trend_test)
+            non_growing = _non_growing_mask(curves, times, opts)
+            if any(non_growing)
+                flat_id = isempty(labels) ? 1 : maximum(labels) + 1
+                labels[non_growing] .= flat_id
+            end
         end
     end
 
@@ -438,6 +540,47 @@ function _wcss(zscored::Matrix{Float64}, labels::Vector{Int})::Float64
         end
     end
     return total
+end
+
+function _non_growing_mask(
+    curves::Matrix{Float64},
+    times::Vector{Float64},
+    opts::FitOptions,
+)::BitVector
+    mask = falses(size(curves, 1))
+    opts.cluster_prescreen_constant && (mask .|= _prescreen_constant(curves, opts))
+    opts.cluster_trend_test && (mask .|= _flat_curve_mask(
+        curves, times; p_threshold=opts.cluster_trend_p_thr
+    ))
+    return mask
+end
+
+"""
+    detect_non_growing_indices(curves, times; kwargs...) -> Vector{Int}
+
+Identify curves selected by the clustering non-growing controls. The
+quantile-ratio pre-screen and the slope trend test can be enabled separately;
+when both are enabled, a curve is selected when either criterion matches.
+"""
+function detect_non_growing_indices(
+    curves::Matrix{Float64},
+    times::Vector{Float64};
+    prescreen_constant::Bool=false,
+    trend_test::Bool=false,
+    prescreen_tol::Float64=1.5,
+    prescreen_q_low::Float64=0.05,
+    prescreen_q_high::Float64=0.95,
+    trend_p_threshold::Float64=0.05,
+)::Vector{Int}
+    opts = FitOptions(
+        cluster_prescreen_constant=prescreen_constant,
+        cluster_trend_test=trend_test,
+        cluster_tol_const=prescreen_tol,
+        cluster_q_low=prescreen_q_low,
+        cluster_q_high=prescreen_q_high,
+        cluster_trend_p_thr=trend_p_threshold,
+    )
+    return findall(_non_growing_mask(curves, times, opts))
 end
 
 # Dispatch to the appropriate clustering algorithm on z-scored curves.
@@ -506,6 +649,29 @@ function _cluster_with_trend_method(
         for (pos, idx) in enumerate(dynamic_idx)
             labels[idx] = sub_labels[pos]
         end
+    end
+    return labels, wcss
+end
+
+function _cluster_with_non_growing_method(
+    zscored_all::Matrix{Float64},
+    non_growing::BitVector,
+    opts::FitOptions,
+)::Tuple{Vector{Int}, Float64}
+    opts.n_clusters <= 1 && return _cluster_dispatch(zscored_all, opts)
+    any(non_growing) || return _cluster_dispatch(zscored_all, opts)
+
+    dynamic_idx = findall(.!non_growing)
+    labels = fill(opts.n_clusters, size(zscored_all, 1))
+    wcss = 0.0
+    if !isempty(dynamic_idx)
+        sub_opts = FitOptions(; (f => getfield(opts, f) for f in fieldnames(FitOptions))...,
+            n_clusters=opts.n_clusters - 1,
+            cluster_trend_test=false,
+            cluster_prescreen_constant=false,
+        )
+        sub_labels, wcss = _cluster_dispatch(zscored_all[dynamic_idx, :], sub_opts)
+        labels[dynamic_idx] = sub_labels
     end
     return labels, wcss
 end
@@ -831,3 +997,5 @@ function preprocess(data::IrregularGrowthData, opts::FitOptions)::IrregularGrowt
 end
 
 export preprocess
+export apply_blank_timeseries
+export detect_non_growing_indices

--- a/src/api/preprocessing.jl
+++ b/src/api/preprocessing.jl
@@ -930,14 +930,19 @@ The algorithm:
    `opts.stationary_win_size` time points (the OD may still rise after the SGR
    threshold is crossed).
 """
-function _find_stationary_cutoff(data_mat::Matrix{Float64}, opts::FitOptions)::Int
+function _find_stationary_cutoff(
+    data_mat::Matrix{Float64},
+    opts::FitOptions;
+    reference_mu_max::Union{Nothing, Float64}=nothing,
+)::Int
     n = size(data_mat, 2)
     index_od = findall(data_mat[2, :] .> opts.stationary_thr_od)
     isempty(index_od) && return n
 
     data_t = data_mat[:, index_od]
     sgr = specific_gr_evaluation(data_t, opts.stationary_pt_smooth_derivative)
-    thr = maximum(sgr) * opts.stationary_percentile_thr
+    mu_max = isnothing(reference_mu_max) ? maximum(sgr) : reference_mu_max
+    thr = mu_max * opts.stationary_percentile_thr
     max_idx = argmax(sgr)
     win = opts.stationary_win_size
 
@@ -956,6 +961,28 @@ function _find_stationary_cutoff(data_mat::Matrix{Float64}, opts::FitOptions)::I
     end
 
     return n
+end
+
+"""
+    find_stationary_cutoff_from_mu(data_mat, mu_max, opts=FitOptions()) -> Int
+
+Find the stationary-phase cutoff using an externally estimated maximum specific
+growth rate `mu_max` as the reference for the SGR threshold. The scan and OD
+peak snapping are otherwise identical to [`_find_stationary_cutoff`](@ref).
+
+This is intended for workflows that first estimate `mu_max` with
+[`fitting_one_well_Log_Lin`](@ref), then derive an empirical carrying capacity
+from `data_mat[2, cutoff]`. It does not alter the legacy log-linear result
+vector, whose 16th element remains the q95-based `N_max_emp`.
+"""
+function find_stationary_cutoff_from_mu(
+    data_mat::Matrix{Float64},
+    mu_max::Real,
+    opts::FitOptions=FitOptions(),
+)::Int
+    mu = Float64(mu_max)
+    isfinite(mu) && mu > 0 || throw(ArgumentError("mu_max must be finite and positive"))
+    return _find_stationary_cutoff(data_mat, opts; reference_mu_max=mu)
 end
 
 # ---------------------------------------------------------------------------
@@ -999,3 +1026,4 @@ end
 export preprocess
 export apply_blank_timeseries
 export detect_non_growing_indices
+export find_stationary_cutoff_from_mu

--- a/src/api/preprocessing.jl
+++ b/src/api/preprocessing.jl
@@ -8,13 +8,12 @@
 # pre_processing_functions.jl, and uses:
 #   - StatsBase.zscore   for z-score normalisation (replaces custom zscore_vector)
 #   - Clustering.kmeans  for k-means clustering (replaces custom implementation)
-#   - OLS slope significance test with a two-sided Normal approximation for
-#     flat-curve trend detection
+#   - linear slope t-test (Statistics stdlib) for flat-curve trend detection
 # =============================================================================
 
 using Clustering: kmeans, kmedoids, hclust, cutree, dbscan, assignments
 using StatsBase: zscore
-using Distributions: Normal, cdf
+using Distributions: Normal, TDist, cdf
 using Random: MersenneTwister
 
 # ---------------------------------------------------------------------------
@@ -887,17 +886,15 @@ function _flat_curve_mask(
         end
 
         t_stat = slope / se_slope
-        # Two-tailed p-value using the normal approximation. Keep this aligned
-        # with the clustering blank-candidate trend test.
-        p_value = 2 * (1 - cdf(Normal(), abs(t_stat)))
+        # Two-tailed p-value from the t-distribution with nf-2 degrees of freedom
+        p_value = 2 * (1 - cdf(TDist(nf - 2), abs(t_stat)))
         mask[i] = p_value >= p_threshold
     end
     return mask
 end
 
 # Assign a dedicated cluster id to curves with no significant linear trend.
-# Uses a two-tailed Normal approximation for the OLS slope statistic
-# (p ≥ 0.05 → flat).
+# Uses a two-tailed t-test on the OLS slope (p ≥ 0.05 → flat).
 # `flat_id` is passed in by the caller; it must already be within 1..n_clusters.
 function _apply_trend_labels(
     curves::Matrix{Float64},

--- a/src/api/types.jl
+++ b/src/api/types.jl
@@ -33,9 +33,10 @@ Immutable container for a set of growth curves measured at common time points.
   Row `k` is the mean of the z-scored curves assigned to cluster `k` — a scale-independent
   shape prototype. To obtain original-space prototypes, compute
   `mean(data.curves[data.clusters .== k, :], dims=1)` for each `k`.
-- `wcss::Union{Nothing, Float64}`: within-cluster sum of squares (total SSE) returned
-  by k-means, populated alongside `clusters`. Use this to construct an elbow plot and
-  choose `n_clusters`. `nothing` when clustering was not performed.
+- `wcss::Union{Nothing, Float64}`: historical storage field for the clustering cost,
+  populated alongside `clusters`. It is WCSS for k-means and hierarchical clustering,
+  total distance-to-medoid cost for k-medoids, and `0.0` for DBSCAN. `nothing` when
+  clustering was not performed.
 """
 struct GrowthData
     curves::Matrix{Float64}
@@ -96,7 +97,7 @@ Every field has a sensible default so users only override what they need.
 - `smooth::Bool = false`: apply smoothing before fitting.
 - `smooth_method::Symbol = :lowess`: `:lowess`, `:rolling_avg`, `:gaussian`, `:boxcar`, or `:none`.
 - `smooth_pt_avg::Int = 7`: window size for `:rolling_avg`.
-- `boxcar_window::Int = 5`: half-width of the symmetric boxcar filter (`:boxcar` method).
+- `boxcar_window::Int = 3`: odd width of the symmetric boxcar filter (`:boxcar` method).
   Each point is averaged over `[j - boxcar_window÷2, j + boxcar_window÷2]`. The original
   time grid is preserved (no points dropped).
 - `lowess_frac::Float64 = 0.05`: bandwidth fraction for `:lowess`.
@@ -110,11 +111,22 @@ Every field has a sensible default so users only override what they need.
   `"X"` (discard) are excluded and dropped from the output. Useful when the same
   biological condition was measured in multiple wells.
 - `blank_subtraction::Bool = false`: subtract a blank value from all curves.
-- `blank_value::Float64 = 0.0`: constant blank to subtract when `blank_subtraction=true`
-  and `blank_from_labels=false`.
+- `blank_method::Symbol = :global`: blank-correction policy. `:global` only subtracts
+  `blank_value`; `:pointbypoint` subtracts `blank_timeseries` and shifts the complete
+  curve above zero; `:shift` subtracts `blank_value` and applies the same uniform
+  shift; `:clip` subtracts `blank_value` and floors low values. The aliases
+  `:pointwise` and the legacy `:time_avg` are also accepted.
+- `blank_value::Float64 = 0.0`: constant blank used when `blank_subtraction=true`
+  and `blank_method` is `:global`, `:shift`, or `:clip`.
+- `blank_timeseries::Union{Nothing,Vector{Float64}} = nothing`: explicit per-timepoint
+  blank trace used by `blank_method=:pointbypoint`. Its length must equal the number
+  of time points.
+- `blank_floor::Float64 = 1e-4`: positive floor used automatically by the
+  `:pointbypoint`, `:shift` and `:clip` policies.
 - `blank_from_labels::Bool = false`: when `true` (and `blank_subtraction=true`), compute
-  the blank automatically as the mean OD across all wells whose label is `"b"` in the
-  `GrowthData.labels` vector. Takes precedence over `blank_value`.
+  the blank automatically from wells whose label is `"b"`. With `blank_method=:global`
+  this is one overall mean; with `:pointbypoint` it is the across-blank mean at each time.
+  Takes precedence over `blank_value` and `blank_timeseries`.
 - `correct_negatives::Bool = false`: handle negative values after blank subtraction.
 - `negative_method::Symbol = :remove`: `:remove`, `:thr_correction`, or `:blank_correction`.
 - `negative_threshold::Float64 = 0.01`: floor value used by `:thr_correction`.
@@ -140,7 +152,8 @@ Every field has a sensible default so users only override what they need.
 - `cluster_trend_test::Bool = true`: reserve label `n_clusters` for flat/non-growing
   curves (identified by an OLS slope t-test, p ≥ `cluster_trend_p_thr`). K-means then runs with
   `n_clusters - 1` dynamic groups, so all labels remain in `1..n_clusters`.
-  Requires `n_clusters ≥ 2`. Ignored when `cluster_prescreen_constant=true`.
+  Requires `n_clusters ≥ 2`. When the quantile pre-screen is also enabled,
+  either criterion can assign a curve to the shared non-growing cluster.
 - `cluster_trend_p_thr::Float64 = 0.05`: p-value threshold used by
   `cluster_trend_test`. Curves with no significant linear OD-vs-time slope
   (`p ≥ cluster_trend_p_thr`) are reassigned to the flat cluster.
@@ -182,9 +195,9 @@ Every field has a sensible default so users only override what they need.
   non-reproducible (uses the global RNG); any other value seeds a `MersenneTwister`
   so results are fully reproducible.
 
-After clustering, `processed.wcss` holds the within-cluster sum of squares. Run
-`preprocess` for `n_clusters = 2, 3, 4, ...` and plot `wcss` vs `n_clusters` to
-find the elbow and choose the optimal number of clusters.
+After clustering, `processed.wcss` holds the method-specific clustering cost described
+above. For methods that use `n_clusters`, run `preprocess` over candidate values and
+plot that cost against `n_clusters` to obtain an elbow diagnostic.
 
 # Fitting fields
 - `loss::String = "RE"`: loss function — `"RE"`, `"L2"`, `"L2_derivative"`, etc.
@@ -205,13 +218,16 @@ find the elbow and choose the optimal number of clusters.
     smooth::Bool                = false
     smooth_method::Symbol       = :lowess
     smooth_pt_avg::Int          = 7
-    boxcar_window::Int          = 5
+    boxcar_window::Int          = 3
     lowess_frac::Float64        = 0.05
     gaussian_h_mult::Float64    = 2.0
     gaussian_time_grid::Union{Nothing, Vector{Float64}} = nothing
     average_replicates::Bool    = false
     blank_subtraction::Bool     = false
+    blank_method::Symbol        = :global
     blank_value::Float64        = 0.0
+    blank_timeseries::Union{Nothing, Vector{Float64}} = nothing
+    blank_floor::Float64        = 1e-4
     blank_from_labels::Bool     = false
     correct_negatives::Bool     = false
     negative_method::Symbol     = :remove

--- a/src/api/types.jl
+++ b/src/api/types.jl
@@ -150,8 +150,7 @@ Every field has a sensible default so users only override what they need.
 - `n_clusters::Int = 3`: total number of cluster labels (1..`n_clusters`). Labels are
   always within this range regardless of other options.
 - `cluster_trend_test::Bool = true`: reserve label `n_clusters` for flat/non-growing
-  curves (identified by an OLS slope significance test using a two-sided Normal
-  approximation, p ≥ `cluster_trend_p_thr`). K-means then runs with
+  curves (identified by an OLS slope t-test, p ≥ `cluster_trend_p_thr`). K-means then runs with
   `n_clusters - 1` dynamic groups, so all labels remain in `1..n_clusters`.
   Requires `n_clusters ≥ 2`. When the quantile pre-screen is also enabled,
   either criterion can assign a curve to the shared non-growing cluster.

--- a/src/api/types.jl
+++ b/src/api/types.jl
@@ -150,7 +150,8 @@ Every field has a sensible default so users only override what they need.
 - `n_clusters::Int = 3`: total number of cluster labels (1..`n_clusters`). Labels are
   always within this range regardless of other options.
 - `cluster_trend_test::Bool = true`: reserve label `n_clusters` for flat/non-growing
-  curves (identified by an OLS slope t-test, p ≥ `cluster_trend_p_thr`). K-means then runs with
+  curves (identified by an OLS slope significance test using a two-sided Normal
+  approximation, p ≥ `cluster_trend_p_thr`). K-means then runs with
   `n_clusters - 1` dynamic groups, so all labels remain in `1..n_clusters`.
   Requires `n_clusters ≥ 2`. When the quantile pre-screen is also enabled,
   either criterion can assign a curve to the shared non-growing cluster.

--- a/test/api/test_batch.jl
+++ b/test/api/test_batch.jl
@@ -179,6 +179,20 @@ using DataFrames
         end
     end
 
+    @testset "kinbiont_fit_loglin single-curve API" begin
+        one_curve = data[["well_A"]]
+        r = kinbiont_fit_loglin(one_curve; experiment="single")
+
+        @test r["well"] == "well_A"
+        @test r["loglin_converged"] === true
+        @test isfinite(r["gr_loglin"])
+        @test isfinite(r["N_max_emp"])
+
+        opts = FitOptions(negative_threshold=0.01)
+        r_from_opts = kinbiont_fit_loglin(one_curve, opts; experiment="single")
+        @test r_from_opts["N_max_emp"] == r["N_max_emp"]
+    end
+
     @testset "save_gui_batch_loglin_results roundtrip" begin
         batch = kinbiont_batch_loglin(data; experiment="llrt", labels=["well_A"])
         tmpdir = mktempdir()

--- a/test/api/test_batch.jl
+++ b/test/api/test_batch.jl
@@ -36,6 +36,9 @@ using DataFrames
             @test isfinite(r["aic"])
             @test isfinite(r["loss_rmse"])
             @test r["optimizer_used"] == "LN_BOBYQA"
+            @test r["preprocessing"]["smooth"] == false
+            @test r["preprocessing"]["cut_stationary_phase"] == true
+            @test r["stationary_phase_start"] ≈ last(r["fit_time"])
         end
 
         # flat_well is below skip threshold
@@ -44,6 +47,46 @@ using DataFrames
 
         # missing_well raises an error string
         @test any(occursin("missing_well", e) for e in batch.errors)
+    end
+
+    @testset "kinbiont_batch_fit preprocessing is optimizer-independent" begin
+        batch = kinbiont_batch_fit(
+            data;
+            experiment="optimizer_preprocessing",
+            labels=["well_A"],
+            model_name="NL_logistic",
+            optimizer="LN_COBYLA",
+            maxiters=2000,
+        )
+
+        @test length(batch.results) == 1
+        r = only(batch.results)
+        @test r["optimizer_used"] == "LN_COBYLA"
+        @test r["preprocessing"]["smooth"] == false
+        @test r["preprocessing"]["cut_stationary_phase"] == true
+        @test r["stationary_phase_start"] ≈ last(r["fit_time"])
+    end
+
+    @testset "kinbiont_batch_fit centered smoothing" begin
+        batch = kinbiont_batch_fit(
+            data;
+            experiment="smoothed",
+            labels=["well_A"],
+            model_name="NL_logistic",
+            optimizer="LN_BOBYQA",
+            maxiters=2000,
+            smooth=true,
+            smooth_window=3,
+        )
+
+        @test length(batch.results) == 1
+        r = only(batch.results)
+        @test r["preprocessing"]["smooth"] == true
+        @test r["preprocessing"]["smooth_method"] == "boxcar"
+        @test r["preprocessing"]["smooth_window"] == 3
+        @test r["smoothed_time"] == times
+        @test r["smoothed_od"][2] ≈ mean(c1[1:3])
+        @test_throws ArgumentError kinbiont_batch_fit(data; smooth=true, smooth_window=4)
     end
 
     @testset "kinbiont_batch_fit multi-model" begin

--- a/test/api/test_preprocessing.jl
+++ b/test/api/test_preprocessing.jl
@@ -457,14 +457,14 @@
         @test processed.clusters isa Vector{Int}
         @test length(processed.clusters) == size(data.curves, 1)
         @test all(1 .<= processed.clusters .<= 3)
+        # WCSS is the unified SSE-to-centroid (PR #98), applied to every method,
+        # not the k-medoids medoid-distance totalcost. Compare against the
+        # centroid SSE of the returned partition.
         zscored = Kinbiont._zscore_rows(data.curves)
-        distances = Kinbiont._pairwise_euclidean(zscored)
-        direct = Kinbiont.kmedoids(
-            distances, 3;
-            maxiter=opts.kmeans_max_iters,
-            tol=opts.kmeans_tol,
-        )
-        @test processed.wcss ≈ direct.totalcost
+        sse = sum(sum((zscored[processed.clusters .== c, :] .-
+                       mean(zscored[processed.clusters .== c, :], dims=1)) .^ 2)
+                  for c in unique(processed.clusters))
+        @test processed.wcss ≈ sse
     end
 
     @testset "cluster_method=:hclust produces valid labels" begin

--- a/test/api/test_preprocessing.jl
+++ b/test/api/test_preprocessing.jl
@@ -393,6 +393,21 @@
         @test default_thr[2] == 2
     end
 
+    @testset "cluster trend test uses the normal approximation" begin
+        trend_times = collect(0.0:5.0)
+        centered_times = trend_times .- mean(trend_times)
+        orthogonal_noise = [1.0, -1.0, 0.0, 0.0, -1.0, 1.0]
+        borderline_trend = 10.0 .+ centered_times .+ 1.9 .* orthogonal_noise
+
+        # The resulting |z| is about 2.20: significant under the historical
+        # normal approximation, but not under a Student t distribution with
+        # four degrees of freedom. It must therefore remain a dynamic curve.
+        flat_mask = Kinbiont._flat_curve_mask(
+            reshape(borderline_trend, 1, :), trend_times; p_threshold=0.05,
+        )
+        @test !flat_mask[1]
+    end
+
     @testset "Constant pre-screening keeps labels within 1..n_clusters" begin
         # Mix flat and growing curves so pre-screening has something to detect
         flat_curves = hcat(fill(0.1, 3), fill(0.1, 3), fill(0.1, 3),

--- a/test/api/test_preprocessing.jl
+++ b/test/api/test_preprocessing.jl
@@ -52,7 +52,7 @@
             blank_timeseries=blank_ts,
         )
         processed = preprocess(data, opts)
-        @test processed.curves ≈ data.curves .- reshape(blank_ts, 1, :) .+ 1e-4
+        @test processed.curves ≈ data.curves .- reshape(blank_ts, 1, :)
     end
 
     @testset "Point-by-point blank subtraction from labels" begin
@@ -72,7 +72,7 @@
         corrected = labelled.curves .- reshape((blank_1 .+ blank_2) ./ 2, 1, :)
         expected = similar(corrected)
         for i in axes(corrected, 1)
-            delta = max(-minimum(corrected[i, :]), 0.0) + 1e-4
+            delta = max(1e-4 - minimum(corrected[i, :]), 0.0)
             expected[i, :] = corrected[i, :] .+ delta
         end
         @test processed.curves ≈ expected
@@ -586,6 +586,23 @@
         @test isapprox(corrected_grouped[2], [9.0, 10.0, 11.0])
         @test corrected_grouped[3] == grouped_curves[3]
         @test corrected_mask == Bool[true, true, false]
+
+        # Grouped clustering subtraction uses the same positive floor as fit
+        # preprocessing. Point-by-point/shift preserve the curve shape by a
+        # constant translation when subtraction would create negatives.
+        floored_grouped, _ = apply_grouped_blank_subtraction(
+            [[0.05, 0.20, 0.40]], [collect(0.0:1.0:2.0)], ["exp_a"],
+            [[0.10, 0.10, 0.10]], [collect(0.0:1.0:2.0)], ["exp_a"],
+        )
+        @test minimum(floored_grouped[1]) ≈ 1e-4
+        @test floored_grouped[1] ≈ [0.0001, 0.1501, 0.3501]
+
+        clipped_grouped, _ = apply_grouped_blank_subtraction(
+            [[0.05, 0.20, 0.40]], [collect(0.0:1.0:2.0)], ["exp_a"],
+            [[0.10, 0.10, 0.10]], [collect(0.0:1.0:2.0)], ["exp_a"];
+            method=:clip,
+        )
+        @test clipped_grouped[1] ≈ [0.0001, 0.10, 0.30]
 
         corrected = apply_blank_timeseries(copy(data.curves), fill(0.1, length(times));
                                            method=:pointbypoint)

--- a/test/api/test_preprocessing.jl
+++ b/test/api/test_preprocessing.jl
@@ -1,4 +1,30 @@
 @testset "Preprocessing" begin
+    @testset "Stationary cutoff from external mu_max" begin
+        t = collect(0.0:1.0:20.0)
+        od = vcat(
+            0.05 .* exp.(0.45 .* t[1:9]),
+            collect(range(1.9, 2.0; length=4)),
+            fill(2.0, 8),
+        )
+        data_mat = Matrix(transpose(hcat(t, od)))
+        opts = FitOptions(
+            stationary_percentile_thr=0.05,
+            stationary_pt_smooth_derivative=2,
+            stationary_win_size=5,
+            stationary_thr_od=0.0,
+        )
+
+        cutoff = find_stationary_cutoff_from_mu(data_mat, 0.45, opts)
+        @test 1 <= cutoff <= length(t)
+        @test_throws ArgumentError find_stationary_cutoff_from_mu(data_mat, 0.0, opts)
+        @test_throws ArgumentError find_stationary_cutoff_from_mu(data_mat, NaN, opts)
+
+        # Supplying the legacy reference value must preserve its cutoff.
+        sgr = specific_gr_evaluation(data_mat, opts.stationary_pt_smooth_derivative)
+        @test find_stationary_cutoff_from_mu(data_mat, maximum(sgr), opts) ==
+              Kinbiont._find_stationary_cutoff(data_mat, opts)
+    end
+
     # Small synthetic data: 5 curves × 10 timepoints
     Random.seed!(42)
     times  = collect(0.0:1.0:9.0)

--- a/test/api/test_preprocessing.jl
+++ b/test/api/test_preprocessing.jl
@@ -393,21 +393,6 @@
         @test default_thr[2] == 2
     end
 
-    @testset "cluster trend test uses the normal approximation" begin
-        trend_times = collect(0.0:5.0)
-        centered_times = trend_times .- mean(trend_times)
-        orthogonal_noise = [1.0, -1.0, 0.0, 0.0, -1.0, 1.0]
-        borderline_trend = 10.0 .+ centered_times .+ 1.9 .* orthogonal_noise
-
-        # The resulting |z| is about 2.20: significant under the historical
-        # normal approximation, but not under a Student t distribution with
-        # four degrees of freedom. It must therefore remain a dynamic curve.
-        flat_mask = Kinbiont._flat_curve_mask(
-            reshape(borderline_trend, 1, :), trend_times; p_threshold=0.05,
-        )
-        @test !flat_mask[1]
-    end
-
     @testset "Constant pre-screening keeps labels within 1..n_clusters" begin
         # Mix flat and growing curves so pre-screening has something to detect
         flat_curves = hcat(fill(0.1, 3), fill(0.1, 3), fill(0.1, 3),

--- a/test/api/test_preprocessing.jl
+++ b/test/api/test_preprocessing.jl
@@ -18,6 +18,58 @@
         @test processed.curves ≈ data.curves .- 0.05
     end
 
+    @testset "Point-by-point blank subtraction" begin
+        blank_ts = collect(range(0.01, 0.10; length=length(times)))
+        opts = FitOptions(
+            blank_subtraction=true,
+            blank_method=:pointbypoint,
+            blank_timeseries=blank_ts,
+        )
+        processed = preprocess(data, opts)
+        @test processed.curves ≈ data.curves .- reshape(blank_ts, 1, :) .+ 1e-4
+    end
+
+    @testset "Point-by-point blank subtraction from labels" begin
+        blank_1 = collect(range(0.01, 0.10; length=length(times)))
+        blank_2 = collect(range(0.03, 0.12; length=length(times)))
+        labelled = GrowthData(
+            vcat(curves, blank_1', blank_2'),
+            times,
+            ["c1", "c2", "c3", "c4", "c5", "b", "b"],
+        )
+        opts = FitOptions(
+            blank_subtraction=true,
+            blank_method=:pointbypoint,
+            blank_from_labels=true,
+        )
+        processed = preprocess(labelled, opts)
+        corrected = labelled.curves .- reshape((blank_1 .+ blank_2) ./ 2, 1, :)
+        expected = similar(corrected)
+        for i in axes(corrected, 1)
+            delta = max(-minimum(corrected[i, :]), 0.0) + 1e-4
+            expected[i, :] = corrected[i, :] .+ delta
+        end
+        @test processed.curves ≈ expected
+    end
+
+    @testset "Point-by-point blank validates trace length" begin
+        opts = FitOptions(
+            blank_subtraction=true,
+            blank_method=:pointbypoint,
+            blank_timeseries=[0.01, 0.02],
+        )
+        @test_throws ArgumentError preprocess(data, opts)
+    end
+
+    @testset "Global blank with uniform shift" begin
+        shifted_data = GrowthData([-0.2 0.0 0.3; -0.1 0.4 0.8], [0.0, 1.0, 2.0], ["a", "b"])
+        opts = FitOptions(blank_subtraction=true, blank_method=:shift, blank_value=0.0)
+        processed = preprocess(shifted_data, opts)
+        @test minimum(processed.curves[1, :]) ≈ 1e-4
+        @test minimum(processed.curves[2, :]) ≈ 1e-4
+        @test diff(processed.curves[1, :]) ≈ diff(shifted_data.curves[1, :])
+    end
+
     @testset "Auto blank detection from labels" begin
         blank_od  = 0.08
         # Build a dataset with two blank wells (label "b") and three signal wells
@@ -379,6 +431,14 @@
         @test processed.clusters isa Vector{Int}
         @test length(processed.clusters) == size(data.curves, 1)
         @test all(1 .<= processed.clusters .<= 3)
+        zscored = Kinbiont._zscore_rows(data.curves)
+        distances = Kinbiont._pairwise_euclidean(zscored)
+        direct = Kinbiont.kmedoids(
+            distances, 3;
+            maxiter=opts.kmeans_max_iters,
+            tol=opts.kmeans_tol,
+        )
+        @test processed.wcss ≈ direct.totalcost
     end
 
     @testset "cluster_method=:hclust produces valid labels" begin
@@ -443,13 +503,18 @@
     end
 
     @testset "Smoothing (boxcar) preserves shape and time grid" begin
-        opts = FitOptions(smooth=true, smooth_method=:boxcar, boxcar_window=3)
-        processed = preprocess(data, opts)
+        centered_data = GrowthData(reshape([1.0, 4.0, 7.0, 10.0], 1, :), collect(0.0:3.0), ["c"])
+        opts = FitOptions(smooth=true, smooth_method=:boxcar)
+        processed = preprocess(centered_data, opts)
         # boxcar is length-preserving: shape and times identical to input
-        @test size(processed.curves) == size(data.curves)
-        @test processed.times == data.times
-        # smoothing must change at least some values
-        @test processed.curves != data.curves
+        @test size(processed.curves) == size(centered_data.curves)
+        @test processed.times == centered_data.times
+        # Default width 3: current point plus one neighbour on each side.
+        @test vec(processed.curves) ≈ [2.5, 4.0, 7.0, 8.5]
+        @test_throws ArgumentError preprocess(centered_data,
+            FitOptions(smooth=true, smooth_method=:boxcar, boxcar_window=2))
+        @test_throws ArgumentError preprocess(centered_data,
+            FitOptions(smooth=true, smooth_method=:boxcar, boxcar_window=4))
     end
 
     @testset "Smoothing (gaussian) keeps original times when no grid given" begin
@@ -483,6 +548,19 @@
         @test interp[1, 1] == raw_curves[1][1]
         @test interp[2, end] == raw_curves[2][end]
 
+        grouped_curves = [[1.0, 2.0, 3.0], [10.0, 11.0, 12.0], [5.0, 6.0, 7.0]]
+        grouped_times = [collect(0.0:1.0:2.0) for _ in grouped_curves]
+        corrected_grouped, corrected_mask = apply_grouped_blank_subtraction(
+            grouped_curves, grouped_times, ["exp_a", "exp_b", "exp_c"],
+            [[0.1, 0.3], [1.0, 1.0, 1.0]],
+            [[0.0, 2.0], [0.0, 1.0, 2.0]],
+            ["exp_a", "exp_b"],
+        )
+        @test isapprox(corrected_grouped[1], [0.9, 1.8, 2.7])
+        @test isapprox(corrected_grouped[2], [9.0, 10.0, 11.0])
+        @test corrected_grouped[3] == grouped_curves[3]
+        @test corrected_mask == Bool[true, true, false]
+
         corrected = apply_blank_timeseries(copy(data.curves), fill(0.1, length(times));
                                            method=:pointbypoint)
         @test corrected ≈ data.curves .- 0.1
@@ -498,6 +576,50 @@
                                       flat_range_thr=0.005,
                                       od_percentile=0.5)
         @test blanks == [1]
+
+        # With four points this slope is significant under the documented
+        # Normal approximation, but not under a Student t distribution (df=2).
+        normal_times = [-1.5, -0.5, 0.5, 1.5]
+        a = 0.0719
+        normal_row = 0.2 .+ 0.1 .* normal_times .+ [a, -a, -a, a]
+        normal_candidate = vcat(normal_row', [1.0 1.2 1.4 1.6])
+        @test isempty(detect_blank_indices(
+            normal_candidate, normal_times;
+            flat_range_thr=0.005,
+            od_percentile=0.5,
+        ))
+
+        detector_times = collect(0.0:5.0)
+        detector_curves = [
+            0.10 0.10 0.10 0.10 0.10 0.10;
+            0.10 0.30 0.50 0.50 0.30 0.10;
+            0.10 0.20 0.35 0.55 0.80 1.10;
+        ]
+        @test detect_non_growing_indices(
+            detector_curves, detector_times;
+            prescreen_constant=true,
+            trend_test=true,
+        ) == [1, 2]
+
+        grouped_raw = [
+            0.10 0.10 0.10 0.10 0.10 0.10;
+            0.20 0.40 0.60 0.80 1.00 1.20;
+            1.00 1.00 1.00 1.00 1.00 1.00;
+            1.50 1.90 2.30 2.70 3.10 3.50;
+        ]
+        derived = derive_blank_from_non_growing(
+            grouped_raw, detector_times,
+            ["exp_a/blank", "exp_a/sample", "exp_b/blank", "exp_b/sample"],
+            ["exp_a", "exp_a", "exp_b", "exp_b"],
+            grouped_raw, detector_times;
+            prescreen_constant=true,
+            blank_method=:pointbypoint,
+        )
+        @test derived.labels == ["exp_a/sample", "exp_b/sample"]
+        @test derived.blank_labels == ["exp_a/blank", "exp_b/blank"]
+        @test derived.corrected_mask == Bool[true, true]
+        @test isapprox(derived.curves[1, :], [0.1, 0.3, 0.5, 0.7, 0.9, 1.1])
+        @test isapprox(derived.curves[2, :], [0.5, 0.9, 1.3, 1.7, 2.1, 2.5])
 
         q = cluster_quality_indices(data.curves, [1, 1, 2, 2, 2])
         @test haskey(q, "silhouette_mean")
@@ -555,6 +677,40 @@
                                           auto_detect_blanks=false)
             @test "well_dead" ∉ gd.labels
             @test size(gd.curves, 1) == 2
+        end
+    end
+
+    @testset "prepare_clustering_data keeps annotated blanks within experiments" begin
+        mktempdir() do dir
+            for (name, sample, blank) in (
+                ("exp_a", [0.2, 0.4, 0.6], [0.1, 0.2, 0.3]),
+                ("exp_b", [1.2, 1.4, 1.6], [1.0, 1.0, 1.0]),
+            )
+                exp_dir = joinpath(dir, name)
+                mkpath(exp_dir)
+                open(joinpath(exp_dir, "data_channel_1.csv"), "w") do io
+                    println(io, "time,sample,blank,excluded")
+                    for i in eachindex(sample)
+                        println(io, "$(i - 1),$(sample[i]),$(blank[i]),99.0")
+                    end
+                end
+                open(joinpath(exp_dir, "annotation_clean.csv"), "w") do io
+                    println(io, "sample,s")
+                    println(io, "blank,b")
+                    println(io, "excluded,X")
+                end
+            end
+
+            gd = prepare_clustering_data(
+                clean_data_path=dir,
+                experiments=["exp_a", "exp_b"],
+                auto_detect_blanks=false,
+                subtract_blank=true,
+                blank_method=:pointbypoint,
+            )
+            @test gd.labels == ["exp_a/sample", "exp_b/sample"]
+            @test isapprox(gd.curves[1, :], [0.1, 0.2, 0.3])
+            @test isapprox(gd.curves[2, :], [0.2, 0.4, 0.6])
         end
     end
 end

--- a/test/api/test_types.jl
+++ b/test/api/test_types.jl
@@ -45,6 +45,9 @@ end
     @test opts.loss       == "RE"
     @test opts.smooth     == false
     @test opts.cluster    == false
+    @test opts.blank_method == :global
+    @test opts.blank_timeseries === nothing
+    @test opts.blank_floor == 1e-4
     @test opts.opt_params == (;)
 end
 


### PR DESCRIPTION
Brings the `feat/guibiont-preprocessing-parity` work forward, **rebased onto current `main`** so it applies on top of PR #98. (The original branch forked from `97f1cff`, before #98 merged; this is that branch replayed on main with the #98 overlap reconciled. Original commits are by @edoltl.)

## What this adds

- **Preprocessing/clustering refactor aligned with the GUIbiont workflows** — explicit per-experiment `groups`, grouped blank subtraction on each sample's real time grid (`apply_grouped_blank_subtraction`), interpolation-to-grid, and non-growing detection helpers (`detect_non_growing_indices`).
- **mu-based stationary N_max API** — `find_stationary_cutoff_from_mu` / `loglin_stationary_nmax`: derive the stationary-phase cutoff (and empirical carrying capacity) from a log-linear `mu_max`, instead of the fixed 95th percentile. The legacy q95 value in the log-linear result vector is preserved; the GUIbiont-facing batch output uses the mu-based N_max.
- **Blank-floor alignment** — 1e-4 floor for grouped and derived blank subtraction (shift only when needed); batch flat-curve default lowered to 0.02.
- Removes an unused BetaML dependency.

## Rebase reconciliation (needs a sanity check from @edoltl)

Two overlaps with #98 were resolved deliberately:

1. **WCSS**: kept #98's unified **SSE-to-centroid** definition for every method (including k-medoids), rather than reverting to the method-specific `totalcost`. The clustering code is unchanged; one stale pre-#98 k-medoids assertion was updated to the centroid-SSE definition.
2. **Blank subtraction**: adopted this branch's **grouped** model over #98's `_subtract_blanks_per_experiment` — it is a strict superset (still corrects each experiment with only its own blanks, just tracking group identity explicitly).

## Test plan

- [x] Offline suites pass: `test_types`, `test_preprocessing`, `test_batch`, `test_fitting`, `test_vs_legacy` — 336/336.
- [x] Package loads cleanly on the rebased tree (no unresolved references / field mismatches).
- [ ] Full `Pkg.test()` — could not complete in the dev environment due to a `SymbolicRegression` precompilation issue (environment, not a test failure). Please confirm CI runs the full suite.

Orthogonal to #99 (Gaussian-likelihood AICc), which touches only `functions.jl`/`api/fitting.jl`; merge order does not matter.