### PR TITLE
fix: support selectable smoothing and GUI export parity

### DIFF
--- a/src/Fit_one_well_functions.jl
+++ b/src/Fit_one_well_functions.jl
@@ -19,6 +19,7 @@ using OptimizationMultistartOptimization
     method_multiple_scattering_correction="interpolation",
     calibration_OD_curve="NA",
     thr_lowess=0.05,
+    gaussian_h_mult=2.0,
     start_exp_win_thr=0.05
     )
 Fits a logarithmic-linear model to data from a .csv file. The function assumes that the first column of the file represents time. It evaluates the specific growth rate, identifies an exponential window based on a statistical threshold, and performs a log-linear fitting.
@@ -30,7 +31,7 @@ Fits a logarithmic-linear model to data from a .csv file. The function assumes t
 
 # Key Arguments:
 
-- `type_of_smoothing="rolling_avg"`: Method of data smoothing. Options are `"NO"`, `"rolling_avg"`, or `"lowess"`.
+- `type_of_smoothing="rolling_avg"`: Method of data smoothing. Options are `"NO"`, `"rolling_avg"`, `"lowess"`, or `"gaussian"`.
 - `pt_avg=7`:  Number of points used in the rolling average smoothing.
 - `pt_smoothing_derivative=7`: Number of points for evaluating specific growth rate. If less than 2, uses interpolation; otherwise, a sliding window approach is used.
 - `pt_min_size_of_win=7`: Minimum size of the exponential windows in terms of the number of smoothed points.
@@ -45,6 +46,7 @@ Fits a logarithmic-linear model to data from a .csv file. The function assumes t
 - `calibration_OD_curve="NA"`: Path to calibration data for multiple scattering correction, used if `multiple_scattering_correction` is true.
 - `method_multiple_scattering_correction="interpolation"`: Method for correcting multiple scattering, options include `"interpolation"` or `"exp_fit"`.
 - `thr_lowess=0.05`: Threshold for lowess smoothing.
+- `gaussian_h_mult=2.0`: Gaussian bandwidth multiplier relative to the median time step.
 - `start_exp_win_thr=0.05`: Minimum OD value that should be reached to start the exponential window.
 
 # Output:
@@ -89,6 +91,7 @@ function fitting_one_well_Log_Lin(
     method_multiple_scattering_correction="interpolation",
     calibration_OD_curve="NA",
     thr_lowess=0.05,
+    gaussian_h_mult=2.0,
     start_exp_win_thr=0.01,
     )
     if multiple_scattering_correction == true
@@ -101,7 +104,8 @@ function fitting_one_well_Log_Lin(
         data;
         method=type_of_smoothing,
         pt_avg=pt_avg,
-        thr_lowess=thr_lowess
+        thr_lowess=thr_lowess,
+        gaussian_h_mult=gaussian_h_mult,
     )
 
 

--- a/src/api/batch.jl
+++ b/src/api/batch.jl
@@ -160,6 +160,12 @@ function _batch_initial_value(param_name, features)
        ((startswith(compact, "n") || startswith(compact, "x") ||
          startswith(compact, "y") || startswith(compact, "od")) && occursin("lag", compact))
         return features[:baseline]
+    elseif compact in ("t0", "tmid", "tmax", "tinf", "tinflection",
+                        "tshift", "tstationary", "tdecaygr", "endsecondlag") ||
+           occursin("inflection", compact) || occursin("midtime", compact)
+        return features[:mid_time]
+    elseif compact == "exitlagrate"
+        return _batch_clip_initial(1.0 / max(features[:lag_time], 0.1); upper=20.0)
     elseif occursin("death", compact) || occursin("decay", compact) ||
            occursin("decline", compact) || occursin("mort", compact) ||
            occursin("inhib", compact) || occursin("inactiv", compact) ||
@@ -172,12 +178,13 @@ function _batch_initial_value(param_name, features)
     elseif compact in ("n0", "x0", "y0", "od0") || occursin("initial", compact) ||
            occursin("inoc", compact) || occursin("baseline", compact)
         return features[:baseline]
+    elseif occursin("mu", compact) || compact in ("r", "gr") ||
+           occursin("growth", compact) || startswith(compact, "gr") ||
+           endswith(compact, "gr")
+        return features[:growth_rate]
     elseif compact in ("lag", "tl", "tlag", "lagtime") || startswith(compact, "tlag") ||
            occursin("lambda", compact) || occursin("delay", compact) || occursin("lag", compact)
         return features[:lag_time]
-    elseif occursin("mu", compact) || compact in ("r", "gr") ||
-           occursin("growth", compact) || occursin("rate", compact) || occursin("gr", compact)
-        return features[:growth_rate]
     elseif compact == "k" || occursin("nmax", compact) || occursin("ymax", compact) ||
            occursin("xmax", compact) || occursin("maxod", compact) ||
            occursin("carrying", compact) || occursin("capacity", compact) ||
@@ -208,25 +215,59 @@ function _batch_param_bounds(model, t, y)
     features = _batch_growth_features(t, y)
     lower = Float64[]
     upper = Float64[]
+    plateau = features[:plateau]
+    amplitude = features[:amplitude]
     plateau_cap = max(features[:plateau] * 3, 1.0)
     time_cap = max(features[:duration] * 2, 10.0)
     for name in model.param_names
         compact = replace(lowercase(String(name)), r"[^a-z0-9]" => "")
-        if occursin("max", compact) || occursin("capacity", compact) || compact == "k" ||
-           occursin("plateau", compact) || occursin("asymptote", compact)
-            push!(lower, 1e-6); push!(upper, plateau_cap)
-        elseif occursin("lag", compact) || occursin("lambda", compact) || occursin("delay", compact)
-            push!(lower, 0.0); push!(upper, max(time_cap, 50.0))
-        elseif occursin("growth", compact) || occursin("rate", compact) ||
-               occursin("mu", compact) || compact in ("r", "gr")
-            push!(lower, 1e-6); push!(upper, 20.0)
-        elseif occursin("shape", compact) || compact in ("nu", "theta", "beta", "gamma", "m", "v")
-            push!(lower, 1e-6); push!(upper, 10.0)
+        bounds = if compact in ("nlag", "xlag", "ylag", "odlag") ||
+           ((startswith(compact, "n") || startswith(compact, "x") ||
+             startswith(compact, "y") || startswith(compact, "od")) && occursin("lag", compact))
+            (1e-6, max(plateau, 1.0))
+        elseif compact in ("t0", "tmid", "tmax", "tinf", "tinflection",
+                            "tshift", "tstationary", "tdecaygr", "endsecondlag") ||
+               occursin("inflection", compact) || occursin("midtime", compact)
+            (0.0, time_cap)
+        elseif compact == "exitlagrate"
+            (0.0, 20.0)
+        elseif occursin("death", compact) || occursin("decay", compact) ||
+               occursin("decline", compact) || occursin("mort", compact) ||
+               occursin("inhib", compact) || occursin("inactiv", compact) ||
+               occursin("resist", compact)
+            (0.0, 20.0)
+        elseif occursin("doubl", compact) || compact in ("dt", "td")
+            (1e-6, time_cap)
         elseif occursin("slope", compact) || occursin("linear", compact)
-            push!(lower, -10.0); push!(upper, 10.0)
+            (-10.0, 10.0)
+        elseif compact in ("n0", "x0", "y0", "od0") ||
+               occursin("initial", compact) || occursin("inoc", compact) ||
+               occursin("baseline", compact)
+            (1e-6, max(plateau, 1.0))
+        elseif occursin("mu", compact) || compact in ("r", "gr") ||
+               occursin("growth", compact) || startswith(compact, "gr") ||
+               endswith(compact, "gr")
+            (1e-6, 20.0)
+        elseif compact in ("lag", "tl", "tlag", "lagtime") ||
+               startswith(compact, "tlag") || occursin("lambda", compact) ||
+               occursin("delay", compact) || occursin("lag", compact)
+            (0.0, max(time_cap, 50.0))
+        elseif compact == "k" || occursin("nmax", compact) || occursin("ymax", compact) ||
+               occursin("xmax", compact) || occursin("maxod", compact) ||
+               occursin("carrying", compact) || occursin("capacity", compact) ||
+               occursin("plateau", compact) || occursin("asymptote", compact)
+            (1e-6, plateau_cap)
+        elseif occursin("amplitude", compact) || compact == "amp"
+            (1e-6, max(amplitude * 5, 1.0))
+        elseif compact in ("q0", "h0")
+            (1e-6, 50.0)
+        elseif occursin("shape", compact) || compact in ("nu", "theta", "beta", "gamma", "m", "v")
+            (1e-6, 10.0)
         else
-            push!(lower, 0.0); push!(upper, 50.0)
+            (0.0, 50.0)
         end
+        push!(lower, bounds[1])
+        push!(upper, bounds[2])
     end
     return lower, upper
 end
@@ -401,7 +442,18 @@ function loglin_stationary_nmax(
     return isfinite(nmax) ? nmax : NaN
 end
 
-function _batch_loglin_fields(t, y, label, experiment; pt_avg=7, pt_deriv=7, pt_min_win=7, threshold=0.9)
+function _batch_loglin_fields(
+    t, y, label, experiment;
+    type_of_smoothing="rolling_avg",
+    pt_avg=7,
+    pt_deriv=7,
+    pt_min_win=7,
+    type_of_win="maximum",
+    threshold=0.9,
+    start_exp_win_thr=0.05,
+    thr_lowess=0.05,
+    gaussian_h_mult=2.0,
+)
     out = Dict{String, Any}(
         "gr_loglin" => NaN,
         "gr_loglin_se" => NaN,
@@ -418,12 +470,15 @@ function _batch_loglin_fields(t, y, label, experiment; pt_avg=7, pt_deriv=7, pt_
     try
         raw = fitting_one_well_Log_Lin(
             Matrix(transpose(hcat(t, y))), label, experiment;
-            type_of_smoothing="rolling_avg",
+            type_of_smoothing=type_of_smoothing,
             pt_avg=pt_avg,
             pt_smoothing_derivative=pt_deriv,
             pt_min_size_of_win=pt_min_win,
-            type_of_win="maximum",
+            type_of_win=type_of_win,
             threshold_of_exp=threshold,
+            start_exp_win_thr=start_exp_win_thr,
+            thr_lowess=thr_lowess,
+            gaussian_h_mult=gaussian_h_mult,
         )
         params = raw[2]
         if length(params) >= 14 && params[7] !== missing
@@ -472,10 +527,15 @@ function _batch_fit_one(
     lowess_frac::Float64=0.05,
     gaussian_h_mult::Float64=2.0,
     compute_loglin::Bool=false,
+    loglin_type_of_smoothing::String="rolling_avg",
     loglin_pt_avg::Int=7,
     loglin_pt_smoothing_derivative::Int=7,
     loglin_pt_min_size_of_win::Int=7,
+    loglin_type_of_win::String="maximum",
     loglin_threshold_of_exp::Float64=0.9,
+    loglin_start_exp_win_thr::Float64=0.05,
+    loglin_thr_lowess::Float64=0.05,
+    loglin_gaussian_h_mult::Float64=2.0,
 )
     resolved_smooth_method = smooth_method == :none && smooth ? :boxcar : smooth_method
     resolved_smooth_method in (:none, :rolling_avg, :lowess, :gaussian, :boxcar) ||
@@ -582,10 +642,15 @@ function _batch_fit_one(
     if compute_loglin
         merge!(result, _batch_loglin_fields(
             time_numeric, od_for_fit, label, experiment;
+            type_of_smoothing=loglin_type_of_smoothing,
             pt_avg=loglin_pt_avg,
             pt_deriv=loglin_pt_smoothing_derivative,
             pt_min_win=loglin_pt_min_size_of_win,
+            type_of_win=loglin_type_of_win,
             threshold=loglin_threshold_of_exp,
+            start_exp_win_thr=loglin_start_exp_win_thr,
+            thr_lowess=loglin_thr_lowess,
+            gaussian_h_mult=loglin_gaussian_h_mult,
         ))
     end
     return result
@@ -634,10 +699,15 @@ function kinbiont_batch_fit(
     lowess_frac::Float64=0.05,
     gaussian_h_mult::Float64=2.0,
     compute_loglin::Bool=false,
+    loglin_type_of_smoothing::String="rolling_avg",
     loglin_pt_avg::Int=7,
     loglin_pt_smoothing_derivative::Int=7,
     loglin_pt_min_size_of_win::Int=7,
+    loglin_type_of_win::String="maximum",
     loglin_threshold_of_exp::Float64=0.9,
+    loglin_start_exp_win_thr::Float64=0.05,
+    loglin_thr_lowess::Float64=0.05,
+    loglin_gaussian_h_mult::Float64=2.0,
     blank_subtraction::Bool=false,
     blank_method::String="pointbypoint",
     blank_value::Real=0.0,
@@ -707,10 +777,15 @@ function kinbiont_batch_fit(
                 lowess_frac=lowess_frac,
                 gaussian_h_mult=gaussian_h_mult,
                 compute_loglin=compute_loglin,
+                loglin_type_of_smoothing=loglin_type_of_smoothing,
                 loglin_pt_avg=loglin_pt_avg,
                 loglin_pt_smoothing_derivative=loglin_pt_smoothing_derivative,
                 loglin_pt_min_size_of_win=loglin_pt_min_size_of_win,
+                loglin_type_of_win=loglin_type_of_win,
                 loglin_threshold_of_exp=loglin_threshold_of_exp,
+                loglin_start_exp_win_thr=loglin_start_exp_win_thr,
+                loglin_thr_lowess=loglin_thr_lowess,
+                loglin_gaussian_h_mult=loglin_gaussian_h_mult,
             ))
         catch e
             push!(errors, "$label: $(string(e))")
@@ -808,6 +883,7 @@ function _batch_fit_loglin_one(
     threshold_of_exp::Float64=0.9,
     start_exp_win_thr::Float64=0.05,
     thr_lowess::Float64=0.05,
+    gaussian_h_mult::Float64=2.0,
     unblanked_floor::Float64=1e-4,
 )
     prepared = _batch_prepare_curve(
@@ -833,6 +909,7 @@ function _batch_fit_loglin_one(
         threshold_of_exp=threshold_of_exp,
         start_exp_win_thr=start_exp_win_thr,
         thr_lowess=thr_lowess,
+        gaussian_h_mult=gaussian_h_mult,
     )
     params = raw[2]
     result = Dict{String, Any}(
@@ -895,6 +972,7 @@ function kinbiont_fit_loglin(
     threshold_of_exp::Float64=0.9,
     start_exp_win_thr::Float64=0.05,
     thr_lowess::Float64=0.05,
+    gaussian_h_mult::Float64=2.0,
 )
     selected_label = isnothing(label) ? only(data.labels) : label
     idx = findfirst(==(selected_label), data.labels)
@@ -922,6 +1000,7 @@ function kinbiont_fit_loglin(
         threshold_of_exp,
         start_exp_win_thr,
         thr_lowess,
+        gaussian_h_mult,
     )
 end
 
@@ -970,6 +1049,7 @@ function kinbiont_batch_loglin(
     threshold_of_exp::Float64=0.9,
     start_exp_win_thr::Float64=0.05,
     thr_lowess::Float64=0.05,
+    gaussian_h_mult::Float64=2.0,
     skip_flat_threshold::Float64=0.02,
 )
     selected = isempty(labels) ? data.labels : labels
@@ -1018,6 +1098,7 @@ function kinbiont_batch_loglin(
                 threshold_of_exp=threshold_of_exp,
                 start_exp_win_thr=start_exp_win_thr,
                 thr_lowess=thr_lowess,
+                gaussian_h_mult=gaussian_h_mult,
             ))
         catch e
             push!(errors, "$label: $(string(e))")

--- a/src/api/batch.jl
+++ b/src/api/batch.jl
@@ -304,7 +304,10 @@ function _batch_run_attempt(
     model_names::Vector{String},
     maxiters::Int,
     abstol::Float64,
-    smooth::Bool,
+    smooth_method::Symbol,
+    smooth_pt_avg::Int,
+    lowess_frac::Float64,
+    gaussian_h_mult::Float64,
     smooth_window::Int,
     optimizer_seed::Int,
 )
@@ -322,8 +325,11 @@ function _batch_run_attempt(
     opt_params = abstol > 0.0 ? (maxiters=maxiters, abstol=abstol) : (maxiters=maxiters,)
     opts = FitOptions(
         scattering_correction=false,
-        smooth=smooth,
-        smooth_method=:boxcar,
+        smooth=smooth_method != :none,
+        smooth_method=smooth_method,
+        smooth_pt_avg=smooth_pt_avg,
+        lowess_frac=lowess_frac,
+        gaussian_h_mult=gaussian_h_mult,
         boxcar_window=smooth_window,
         cut_stationary_phase=true,
         stationary_percentile_thr=0.05,
@@ -461,15 +467,26 @@ function _batch_fit_one(
     abstol::Float64=1e-15,
     smooth::Bool=false,
     smooth_window::Int=3,
+    smooth_method::Symbol=:none,
+    smooth_pt_avg::Int=7,
+    lowess_frac::Float64=0.05,
+    gaussian_h_mult::Float64=2.0,
     compute_loglin::Bool=false,
     loglin_pt_avg::Int=7,
     loglin_pt_smoothing_derivative::Int=7,
     loglin_pt_min_size_of_win::Int=7,
     loglin_threshold_of_exp::Float64=0.9,
 )
-    if smooth && (smooth_window < 3 || iseven(smooth_window))
+    resolved_smooth_method = smooth_method == :none && smooth ? :boxcar : smooth_method
+    resolved_smooth_method in (:none, :rolling_avg, :lowess, :gaussian, :boxcar) ||
+        throw(ArgumentError("Unknown smoothing method: $resolved_smooth_method"))
+    if resolved_smooth_method == :boxcar && (smooth_window < 3 || iseven(smooth_window))
         throw(ArgumentError("smooth_window must be an odd integer greater than or equal to 3"))
     end
+    smooth_pt_avg >= 3 || throw(ArgumentError("smooth_pt_avg must be at least 3"))
+    0.0 < lowess_frac <= 1.0 || throw(ArgumentError("lowess_frac must be in (0, 1]"))
+    gaussian_h_mult > 0.0 || throw(ArgumentError("gaussian_h_mult must be positive"))
+    smooth_enabled = resolved_smooth_method != :none
 
     prepared = _batch_prepare_curve(
         od_raw;
@@ -503,7 +520,8 @@ function _batch_fit_one(
             res = _batch_run_attempt(
                 opt, time_numeric, od_for_fit, shift,
                 subtract_blank, blank_value, label, model_name, model_names,
-                maxiters, abstol, smooth, smooth_window, attempt_seed,
+                maxiters, abstol, resolved_smooth_method, smooth_pt_avg,
+                lowess_frac, gaussian_h_mult, smooth_window, attempt_seed,
             )
             push!(outcomes, (optimizer=opt, run=run_idx, seed=attempt_seed, status="ok", loss=res.loss_rmse,
                 loss_rmse=res.loss_rmse, loss_re=res.loss_re, aic=res.aic, result=res))
@@ -534,9 +552,12 @@ function _batch_fit_one(
         "maxiters" => maxiters,
         "abstol" => abstol,
         "preprocessing" => Dict(
-            "smooth" => smooth,
-            "smooth_method" => smooth ? "boxcar" : "none",
+            "smooth" => smooth_enabled,
+            "smooth_method" => String(resolved_smooth_method),
             "smooth_window" => smooth_window,
+            "smooth_pt_avg" => smooth_pt_avg,
+            "lowess_frac" => lowess_frac,
+            "gaussian_h_mult" => gaussian_h_mult,
             "cut_stationary_phase" => true,
             "stationary_percentile_thr" => 0.05,
             "stationary_pt_smooth_derivative" => 10,
@@ -554,7 +575,7 @@ function _batch_fit_one(
             "loss_re" => o.loss_re, "aic" => o.aic) for o in outcomes],
     )
     od_subtracted_display !== nothing && (result["experimental_od_subtracted"] = od_subtracted_display)
-    if smooth
+    if smooth_enabled
         result["smoothed_time"] = win.preprocessed_time
         result["smoothed_od"] = win.preprocessed_od
     end
@@ -586,9 +607,11 @@ minimized by Kinbiont, whereas `loss_rmse` is recomputed against the same
 preprocessed observations through the Kinbiont stationary-phase cutoff.
 GUIbiont selects the optimizer attempt with the lowest `loss_rmse`.
 
-Set `smooth=true` to apply the same centered moving average to every optimizer
-attempt before stationary-phase detection. `smooth_window` is the odd window
-width and defaults to 3 (one point on either side of the current point).
+Set `smooth=true` and choose `smooth_method=:rolling_avg`, `:lowess`, or
+`:gaussian` to apply the same smoothing to every optimizer attempt before
+stationary-phase detection. The corresponding parameter is `smooth_pt_avg`,
+`lowess_frac`, or `gaussian_h_mult`. The legacy centered average remains
+available through `smooth=true, smooth_window=3`.
 """
 function kinbiont_batch_fit(
     data::GrowthData;
@@ -606,6 +629,10 @@ function kinbiont_batch_fit(
     skip_flat_threshold::Float64=0.02,
     smooth::Bool=false,
     smooth_window::Int=3,
+    smooth_method::Symbol=:none,
+    smooth_pt_avg::Int=7,
+    lowess_frac::Float64=0.05,
+    gaussian_h_mult::Float64=2.0,
     compute_loglin::Bool=false,
     loglin_pt_avg::Int=7,
     loglin_pt_smoothing_derivative::Int=7,
@@ -616,9 +643,16 @@ function kinbiont_batch_fit(
     blank_value::Real=0.0,
     blank_timeseries::Vector{Float64}=Float64[],
 )
-    if smooth && (smooth_window < 3 || iseven(smooth_window))
+    resolved_smooth_method = smooth_method == :none && smooth ? :boxcar : smooth_method
+    resolved_smooth_method in (:none, :rolling_avg, :lowess, :gaussian, :boxcar) ||
+        throw(ArgumentError("Unknown smoothing method: $resolved_smooth_method"))
+    if resolved_smooth_method == :boxcar && (smooth_window < 3 || iseven(smooth_window))
         throw(ArgumentError("smooth_window must be an odd integer greater than or equal to 3"))
     end
+    smooth_pt_avg >= 3 || throw(ArgumentError("smooth_pt_avg must be at least 3"))
+    0.0 < lowess_frac <= 1.0 || throw(ArgumentError("lowess_frac must be in (0, 1]"))
+    gaussian_h_mult > 0.0 || throw(ArgumentError("gaussian_h_mult must be positive"))
+    smooth_enabled = resolved_smooth_method != :none
 
     selected = isempty(labels) ? data.labels : labels
     results = Dict{String, Any}[]
@@ -666,8 +700,12 @@ function kinbiont_batch_fit(
                 optimizer_seed=optimizer_seed,
                 maxiters=maxiters,
                 abstol=abstol,
-                smooth=smooth,
+                smooth=smooth_enabled,
                 smooth_window=smooth_window,
+                smooth_method=resolved_smooth_method,
+                smooth_pt_avg=smooth_pt_avg,
+                lowess_frac=lowess_frac,
+                gaussian_h_mult=gaussian_h_mult,
                 compute_loglin=compute_loglin,
                 loglin_pt_avg=loglin_pt_avg,
                 loglin_pt_smoothing_derivative=loglin_pt_smoothing_derivative,
@@ -685,8 +723,12 @@ function kinbiont_batch_fit(
         experiment=experiment,
         model=model_out,
         model_names=model_names_out,
-        smooth=smooth,
+        smooth=smooth_enabled,
+        smooth_method=resolved_smooth_method,
         smooth_window=smooth_window,
+        smooth_pt_avg=smooth_pt_avg,
+        lowess_frac=lowess_frac,
+        gaussian_h_mult=gaussian_h_mult,
         results=results,
         skipped=skipped,
         errors=errors,

--- a/src/api/clustering_helpers.jl
+++ b/src/api/clustering_helpers.jl
@@ -791,6 +791,7 @@ function prepare_clustering_data(;
     blank_trend_p_threshold::Float64 = 0.05,
     detection_smooth::Bool = false,
     detection_smooth_method::Symbol = :lowess,
+    detection_smooth_pt_avg::Int = 7,
     detection_lowess_frac::Float64 = 0.05,
     detection_gaussian_h_mult::Float64 = 2.0,
 )::GrowthData
@@ -862,6 +863,7 @@ function prepare_clustering_data(;
                 FitOptions(
                     smooth=true,
                     smooth_method=detection_smooth_method,
+                    smooth_pt_avg=detection_smooth_pt_avg,
                     lowess_frac=detection_lowess_frac,
                     gaussian_h_mult=detection_gaussian_h_mult,
                     cluster=false,

--- a/test/api/test_batch.jl
+++ b/test/api/test_batch.jl
@@ -12,6 +12,32 @@ using DataFrames
     curves = vcat(reshape(c1, 1, :), reshape(c2, 1, :), reshape(flat, 1, :))
     data   = GrowthData(curves, times, ["well_A", "well_B", "flat_well"])
 
+    @testset "model parameter semantics" begin
+        features = Kinbiont._batch_growth_features(times, vec(c1))
+        @test Kinbiont._batch_initial_value("exit_lag_rate", features) ==
+              1.0 / max(features[:lag_time], 0.1)
+        @test Kinbiont._batch_initial_value("lag_2_gr", features) == features[:growth_rate]
+        @test Kinbiont._batch_initial_value("gr_lag", features) == features[:growth_rate]
+        @test Kinbiont._batch_initial_value("t_decay_gr", features) == features[:mid_time]
+        @test Kinbiont._batch_initial_value("t_stationary", features) == features[:mid_time]
+
+        hpm = Kinbiont.MODEL_REGISTRY["HPM"]
+        hpm_lower, hpm_upper = Kinbiont._batch_param_bounds(hpm, times, vec(c1))
+        exit_idx = findfirst(==("exit_lag_rate"), hpm.param_names)
+        @test (hpm_lower[exit_idx], hpm_upper[exit_idx]) == (0.0, 20.0)
+
+        diauxic = Kinbiont.MODEL_REGISTRY["Diauxic_piecewise_adjusted_logistic"]
+        diauxic_lower, diauxic_upper = Kinbiont._batch_param_bounds(diauxic, times, vec(c1))
+        lag_gr_idx = findfirst(==("lag_2_gr"), diauxic.param_names)
+        @test (diauxic_lower[lag_gr_idx], diauxic_upper[lag_gr_idx]) == (1e-6, 20.0)
+
+        four_phase = Kinbiont.MODEL_REGISTRY["ODE_four_piecewise"]
+        time_lower, time_upper = Kinbiont._batch_param_bounds(four_phase, times, vec(c1))
+        decay_time_idx = findfirst(==("t_decay_gr"), four_phase.param_names)
+        @test time_lower[decay_time_idx] == 0.0
+        @test time_upper[decay_time_idx] == max(features[:duration] * 2, 10.0)
+    end
+
     @testset "blank-subtracted display is the fitted array" begin
         shifted = Kinbiont._batch_prepare_curve(
             [0.05, 0.20, 0.40];
@@ -160,6 +186,8 @@ using DataFrames
             optimizer="LN_BOBYQA",
             maxiters=2000,
             compute_loglin=true,
+            loglin_type_of_smoothing="gaussian",
+            loglin_gaussian_h_mult=1.5,
         )
 
         @test length(batch.results) == 1
@@ -223,6 +251,17 @@ using DataFrames
             @test isfinite(r["gr_loglin"])
             @test isfinite(r["R_squared_loglin"])
         end
+
+        gaussian_batch = kinbiont_batch_loglin(
+            data;
+            experiment="ll_gaussian",
+            labels=["well_A"],
+            type_of_smoothing="gaussian",
+            gaussian_h_mult=1.5,
+        )
+        @test isempty(gaussian_batch.errors)
+        @test length(gaussian_batch.results) == 1
+        @test only(gaussian_batch.results)["loglin_converged"] === true
     end
 
     @testset "kinbiont_fit_loglin single-curve API" begin
@@ -233,6 +272,15 @@ using DataFrames
         @test r["loglin_converged"] === true
         @test isfinite(r["gr_loglin"])
         @test isfinite(r["N_max_emp"])
+
+        r_gaussian = kinbiont_fit_loglin(
+            one_curve;
+            experiment="single_gaussian",
+            type_of_smoothing="gaussian",
+            gaussian_h_mult=1.5,
+        )
+        @test r_gaussian["loglin_converged"] === true
+        @test isfinite(r_gaussian["gr_loglin"])
 
         opts = FitOptions(negative_threshold=0.01)
         r_from_opts = kinbiont_fit_loglin(one_curve, opts; experiment="single")

--- a/test/api/test_batch.jl
+++ b/test/api/test_batch.jl
@@ -109,6 +109,32 @@ using DataFrames
         @test_throws ArgumentError kinbiont_batch_fit(data; smooth=true, smooth_window=4)
     end
 
+    @testset "kinbiont_batch_fit selectable smoothing" begin
+        cases = [
+            (:rolling_avg, (; smooth_pt_avg=5)),
+            (:lowess, (; lowess_frac=0.2)),
+            (:gaussian, (; gaussian_h_mult=1.5)),
+        ]
+        for (method, method_kwargs) in cases
+            batch = kinbiont_batch_fit(
+                data;
+                experiment="smoothed_$(method)",
+                labels=["well_A"],
+                model_name="NL_logistic",
+                optimizer="LN_BOBYQA",
+                maxiters=2000,
+                smooth=true,
+                smooth_method=method,
+                method_kwargs...,
+            )
+            @test length(batch.results) == 1
+            preprocessing = only(batch.results)["preprocessing"]
+            @test preprocessing["smooth"] == true
+            @test preprocessing["smooth_method"] == String(method)
+            @test !isempty(only(batch.results)["smoothed_od"])
+        end
+    end
+
     @testset "kinbiont_batch_fit multi-model" begin
         batch = kinbiont_batch_fit(
             data;

--- a/test/api/test_preprocessing.jl
+++ b/test/api/test_preprocessing.jl
@@ -901,6 +901,9 @@
                 derive_non_growing_blanks=true,
                 blank_trend_test=true,
                 blank_method=:pointbypoint,
+                detection_smooth=true,
+                detection_smooth_method=:rolling_avg,
+                detection_smooth_pt_avg=3,
             )
             @test gd.labels == ["exp_a/sample"]
             expected_times = collect(range(0.0, 4.0; length=10))


### PR DESCRIPTION
## Summary

  - Add Gaussian smoothing support to single and batch Log-Lin fitting.
  - Expose all Log-Lin companion smoothing and window settings in the public batch API.
  - Support selectable Rolling Average, LOWESS, and Gaussian smoothing for parametric batch fitting.
  - Expose the Rolling Average detection window used for clustering blank detection.
  - Align the public API with GUIbiont's dynamically exported code.
  - Derive initial values and optimizer bounds using explicit model-parameter semantics.
  - Keep `exit_lag_rate`, phase growth rates, event times, and death/inhibition rates distinct.

  ## Validation

  - Kinbiont batch API tests: 118/118 passed.
  - Preprocessing and clustering tests passed.
  - Numerical parity with GUIbiont verified for parametric fitting, Gaussian Log-Lin, and clustering.